### PR TITLE
Remove support for testing under Oracle JDK 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: clojure
 script: lein all test
 jdk:
   - openjdk7
-  - oraclejdk7
   - openjdk8
   - oraclejdk8
   - oraclejdk9


### PR DESCRIPTION
Travis no longer supports Oracle JDK 7 because it has reached end of
life: https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images