### PR TITLE
Liberate insert-whitespace-friends

### DIFF
--- a/src/rewrite_clj/zip.clj
+++ b/src/rewrite_clj/zip.clj
@@ -76,7 +76,9 @@
    skip skip-whitespace
    skip-whitespace-left
    prepend-space append-space
-   prepend-newline append-newline])
+   prepend-newline append-newline
+   insert-space-left insert-space-right
+   insert-newline-left insert-newline-right])
 
 ;; ## Base Operations
 


### PR DESCRIPTION
insert-space-left, insert-space-right, insert-newline-left, and insert-newline-right were born in 0.5.0, but sadly hidden in the darkness.

This change attempts to restore freedom to all whitespace lovers.