### PR TITLE
Allow use of newline functions in whitespace namespace

### DIFF
--- a/src/rewrite_clj/zip.clj
+++ b/src/rewrite_clj/zip.clj
@@ -76,7 +76,8 @@
    skip skip-whitespace
    skip-whitespace-left
    prepend-space append-space
-   prepend-newline append-newline])
+   prepend-newline append-newline
+   insert-newline-left insert-newline-right])
 
 ;; ## Base Operations
 


### PR DESCRIPTION
Two functions were not exported, and thus were unable to be used.