### PR TITLE
Fix end position on root node of untracked zipper

### DIFF
--- a/src/rewrite_clj/parser.cljc
+++ b/src/rewrite_clj/parser.cljc
@@ -23,12 +23,11 @@
   "Parse all forms from the given reader."
   [#?(:cljs ^not-native reader :default reader)]
   (let [nodes (->> (repeatedly #(parse reader))
-                   (take-while identity)
-                   (doall))]
-    (with-meta
-      (nforms/forms-node nodes)
-      (merge (meta (first nodes))
-             (select-keys (meta (last nodes)) [:end-row :end-col])))))
+                   (take-while identity))
+        position-meta (merge (meta (first nodes))
+                             (select-keys (meta (last nodes))
+                                          [:end-row :end-col]))]
+    (with-meta (nforms/forms-node nodes) position-meta)))
 
 ;; ## Specialized Parsers
 

--- a/src/rewrite_clj/parser.cljc
+++ b/src/rewrite_clj/parser.cljc
@@ -27,7 +27,8 @@
                    (doall))]
     (with-meta
       (nforms/forms-node nodes)
-      (meta (first nodes)))))
+      (merge (meta (first nodes))
+             (select-keys (meta (last nodes)) [:end-row :end-col])))))
 
 ;; ## Specialized Parsers
 

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -541,7 +541,18 @@
       [2 4]  [2 5]  :token  "x"            'x
       [3 3]  [3 14] :list   "(println x)"  '(println x)
       [3 4]  [3 11] :token  "println"      'println
-      [3 12] [3 13] :token  "x"            'x)))
+      [3 12] [3 13] :token  "x"            'x))
+  ;; root node
+  (let [s (str
+           ;1234567890
+           "(def a 1)\n"
+           "(def b\n"
+           "  2)")
+        n (p/parse-string-all s)
+        start-pos ((juxt :row :col) (meta n))
+        end-pos ((juxt :end-row :end-col) (meta n))]
+    (is (= [1 1] start-pos))
+    (is (= [3 5] end-pos))))
 
 
 (deftest t-os-specific-line-endings

--- a/test/rewrite_clj/zip_test.cljc
+++ b/test/rewrite_clj/zip_test.cljc
@@ -58,7 +58,18 @@
       [2 4]  [2 5]  :token  "x"            'x
       [3 3]  [3 14] :list   "(println x)"  '(println x)
       [3 4]  [3 11] :token  "println"      'println
-      [3 12] [3 13] :token  "x"            'x)))
+      [3 12] [3 13] :token  "x"            'x))
+  ;; root node
+  (let [s (str
+           ;1234567890
+           "(def a 1)\n"
+           "(def b\n"
+           "  2)")
+        [start-pos end-pos] (-> (z/of-string s {:track-position? true})
+                                z/up
+                                z/position-span)]
+    (is (= [1 1] start-pos))
+    (is (= [3 5] end-pos))))
 
 (deftest namespaced-keywords
   (is (= ":dill" (-> ":dill" z/of-string z/root-string)))


### PR DESCRIPTION
The end position of the root node of a parsed string was inherited from the first child. This meant that the root node looked like it spanned only one child, instead of all of its children. This fix makes the root node take its end position from its last child.

After this fix, the end position of an untracked zipper (which uses the parser's data) matches the end position of a tracked zipper (which uses node extents).

This fixes #173. My one concern with this approach is that it uses `last`, meaning an additional iteration over the root node's children. Since `parse-all` already does a `doall` on the children, this isn't forcing a previously lazy sequence. But, I suppose it could still be a slight performance degradation. If you'd like I can benchmark before and after. One option would be to remove the `doall` and rely on `last` to force the full sequence. I think that would keep the number of iterations the same as originally. It depends a bit on what the `doall` is for. It's been present since 2014, and it's hard to tell exactly why it was added (f1e348832ef103e5142f57dcfcc78aad27a062df). Are you aware of what it does? Maybe it forces everything to be parsed before a file is closed? Anyway, I'll rely on your guidance to decide whether this needs more thought.