### PR TITLE
Transport position in ex-data

### DIFF
--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -18,12 +18,15 @@
 (defn throw-reader
   "Throw reader exception, including line line/column."
   [#?(:cljs ^:not-native reader :default reader) fmt & data]
-  (let [c (r/get-column-number reader)
+  (let [m (apply interop/simple-format fmt data)
+        c (r/get-column-number reader)
         l (r/get-line-number reader)]
     (throw
      (ex-info
-      (str (apply interop/simple-format fmt data)
-           " [at line " l ", column " c "]") {}))))
+      (str m " [at line " l ", column " c "]")
+      {:msg m
+       :row l
+       :col c}))))
 
 ;; ## Decisions
 

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -587,6 +587,6 @@
 
 (deftest t-position-in-ex-data
   (let [ex (try (p/parse-string "(defn foo [)")
-                (catch Exception e e))]
+                (catch #?(:clj Exception :cljs :default) e e))]
     (is (= 1 (-> ex ex-data :row)))
     (is (= 12 (-> ex ex-data :col)))))

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -554,7 +554,6 @@
     (is (= [1 1] start-pos))
     (is (= [3 5] end-pos))))
 
-
 (deftest t-os-specific-line-endings
   (are [?in ?expected]
     (let [str-actual (-> ?in p/parse-string-all node/string)]
@@ -585,3 +584,9 @@
     ;1   2 3   4   5 6   7
     "\r\n\r\r\f\r\n\r\r\n\r"
     "\n\n\n\n\n\n\n"))
+
+(deftest t-position-in-ex-data
+  (let [ex (try (p/parse-string "(defn foo [)")
+                (catch Exception e e))]
+    (is (= 1 (-> ex ex-data :row)))
+    (is (= 12 (-> ex ex-data :col)))))


### PR DESCRIPTION
Exceptions thrown by the reader will have `:row` and `:col` keys in their ex-data.