### PR TITLE
Add MIT License to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,13 @@
     <connection>scm:git:git@github.com:clj-commons/rewrite-clj.git</connection>
     <developerConnection>scm:git:git@github.com:clj-commons/rewrite-clj.git</developerConnection>
   </scm>
+  <licenses>
+    <license>
+      <name>The MIT License</name>
+      <url>http://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
`rewrite-clj` is distributed under the MIT license, but this is not reflected in the `pom.xml`. Therefore tools like `clojure -T:deps list` will not recognise the license.

This PR adds a `<licenses>` tag to `pom.xml`.