### PR TITLE
ci and unit test deps: bump

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,7 +25,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
         bb: 'latest'

--- a/.github/workflows/libs-test.yml
+++ b/.github/workflows/libs-test.yml
@@ -23,7 +23,7 @@ jobs:
         restore-keys: ${{ runner.os }}-clj-libs-deps-
 
     - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
         bb: 'latest'
@@ -69,7 +69,7 @@ jobs:
         sudo apt-get install -y planck
 
     - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
         bb: 'latest'

--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install GraalVM
       uses: graalvm/setup-graalvm@v1
       with:
-        version: '22.2.0'
+        version: '22.3.0'
         java-version: ${{ matrix.graal-java }}
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
     # Install Babashka
     #
     - name: Install Babashka
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         bb: 'latest'
 
@@ -61,7 +61,7 @@ jobs:
       if: matrix.os == 'windows'
 
     - name: Install Clojure (macos, linux)
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
       if: matrix.os != 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
         bb: 'latest'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,7 +32,7 @@ jobs:
         java-version: '11'
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
         bb: 'latest'
@@ -107,7 +107,7 @@ jobs:
     # Install Babashka
     #
     - name: Install Babashka
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         bb: 'latest'
 
@@ -123,7 +123,7 @@ jobs:
       if: matrix.os == 'windows'
 
     - name: Install Clojure (macos, linux)
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@10.0
       with:
         cli: 'latest'
       if: matrix.os != 'windows'

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:min-bb-version "0.9.162"
  :paths ["script" "build"]
  :deps {org.clojure/data.zip {:mvn/version "1.0.0"}
-        io.aviso/pretty {:mvn/version "1.2"}
+        io.aviso/pretty {:mvn/version "1.3"}
         dev.nubank/docopt {:mvn/version "0.6.1-fix7"}
         doric/doric {:mvn/version "0.9.0"}
         version-clj/version-clj {:mvn/version "2.0.2"}

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
            ;;
            :lint-cache {:replace-paths ["src"]} ;; when building classpath we want to exclude resources
                                                 ;; so we do not pick up our own clj-kondo config exports
-           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.10.05"}}
+           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.11.02"}}
                        :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
                        :main-opts ["-m" "clj-kondo.main"]}
 
@@ -58,7 +58,7 @@
                        :extra-paths ["target/test-doc-blocks/test"]}
 
            ;; kaocha for testing clojure versions>= v1.9
-           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.70.1086"}
+           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.71.1119"}
                                  lambdaisland/kaocha-junit-xml {:mvn/version "1.16.98"}
                                  lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}
                     :main-opts ["-m" "kaocha.runner"]}
@@ -91,8 +91,8 @@
                                  cli-matic/cli-matic {:mvn/version "0.5.4"}}}
 
            :apply-import-vars {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
-                               :extra-deps {metosin/malli {:mvn/version "0.8.9"}
-                                            io.aviso/pretty {:mvn/version "1.2"}}
+                               :extra-deps {metosin/malli {:mvn/version "0.9.2"}
+                                            io.aviso/pretty {:mvn/version "1.3"}}
                                :ns-default lread.apply-import-vars}
 
            ;;
@@ -134,7 +134,7 @@
            ;;
            ;; Maintenance support
            ;;
-           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.1.932"}
+           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.1.939"}
                                    org.slf4j/slf4j-simple {:mvn/version "2.0.3"} ;; to rid ourselves of logger warnings
                                    }
                       :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -20,7 +20,7 @@ Automated testing is setup using GraalVM v22 JDK11.
 * Clojure v1.10.1.697 or above for `clojure` command
 ** Note that rewrite-clj v1 itself supports Clojure v1.8 and above
 * Babashka v0.3.7 or above
-* GraalVM v22.2.0 JDK 11 or 17 (if you want to run GraalVM native image tests)
+* GraalVM v22.3.0 JDK 11 or 17 (if you want to run GraalVM native image tests)
 
 === Windows Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
     "": {
       "name": "rewrite-clj",
       "devDependencies": {
-        "karma": "^6.4.0",
+        "karma": "^6.4.1",
         "karma-chrome-launcher": "^3.1.1",
         "karma-cljs-test": "^0.1.0",
         "karma-junit-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.34",
-        "shadow-cljs": "^2.20.1"
+        "shadow-cljs": "^2.20.7"
       }
     },
     "node_modules/@colors/colors": {
@@ -42,9 +42,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -1492,10 +1492,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -1956,9 +1959,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.2.tgz",
-      "integrity": "sha512-2kzWnV1QM6KBetziCAkCf8BJdnDX2CwiAr4yhvOsiQpaNJcMzwMsJTX/gTHz58yQg0dV5uwPsIyBlvyIfl30rg==",
+      "version": "2.20.7",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.7.tgz",
+      "integrity": "sha512-G/XGarZvWiBCxu5C1ZQAV6X5bZqpO8f3wH4FRN2VruQXzYLX/vf3rJ0DOU2Y9gT64X66zqegZWSohQKklOivJA==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -1996,9 +1999,9 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.2.tgz",
-      "integrity": "sha512-6fCnk4ARMPZN448+SQcnn1u8OHUC72puJcNtSgg2xS34Cu7br1gQ09YKkO1PFfDn/wyUE9ZgMAwosJed003+NQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
+      "integrity": "sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
@@ -2279,9 +2282,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
       "dev": true,
       "funding": [
         {
@@ -2522,9 +2525,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "accepts": {
@@ -3705,9 +3708,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mkdirp": {
@@ -4083,9 +4086,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.2.tgz",
-      "integrity": "sha512-2kzWnV1QM6KBetziCAkCf8BJdnDX2CwiAr4yhvOsiQpaNJcMzwMsJTX/gTHz58yQg0dV5uwPsIyBlvyIfl30rg==",
+      "version": "2.20.7",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.7.tgz",
+      "integrity": "sha512-G/XGarZvWiBCxu5C1ZQAV6X5bZqpO8f3wH4FRN2VruQXzYLX/vf3rJ0DOU2Y9gT64X66zqegZWSohQKklOivJA==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",
@@ -4114,9 +4117,9 @@
       }
     },
     "socket.io": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.2.tgz",
-      "integrity": "sha512-6fCnk4ARMPZN448+SQcnn1u8OHUC72puJcNtSgg2xS34Cu7br1gQ09YKkO1PFfDn/wyUE9ZgMAwosJed003+NQ==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.3.tgz",
+      "integrity": "sha512-zdpnnKU+H6mOp7nYRXH4GNv1ux6HL6+lHL8g7Ds7Lj8CkdK1jJK/dlwsKDculbyOHifcJ0Pr/yeXnZQ5GeFrcg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -4342,9 +4345,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "karma-cljs-test": "^0.1.0",
     "karma-junit-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.34",
-    "shadow-cljs": "^2.20.2"
+    "shadow-cljs": "^2.20.7"
   }
 }

--- a/script/helper/env.clj
+++ b/script/helper/env.clj
@@ -8,11 +8,15 @@
   "Asserts minimum version of Clojure version"
   []
   (let [min-version "1.10.1.697"
-        version
-        (->> (shell/command {:out :string} "clojure -Sdescribe")
-             :out
-             edn/read-string
-             :version)]
+        result (shell/command {:out :string} "clojure -Sdescribe")
+        _ (println "ret from clojure -Sdescribe" (pr-str result))
+        version (->> result
+                     :out
+                     edn/read-string
+                     :version)]
+    (when-not version
+      (throw (ex-info "huh, version is nil" {})))
+    (println "parsed version:" (pr-str version))
     (when (< (ver/version-compare version min-version) 0)
       (status/die 1
                   "A  minimum version of Clojure %s required.\nFound version: %s"

--- a/script/helper/env.clj
+++ b/script/helper/env.clj
@@ -9,14 +9,14 @@
   []
   (let [min-version "1.10.1.697"
         result (shell/command {:out :string} "clojure -Sdescribe")
-        _ (println "ret from clojure -Sdescribe" (pr-str result))
+        _ (.println *err* (str "ret from clojure -Sdescribe: " (pr-str result)))
         version (->> result
                      :out
                      edn/read-string
                      :version)]
     (when-not version
       (throw (ex-info "huh, version is nil" {})))
-    (println "parsed version:" (pr-str version))
+    (.println *err* (str "parsed version: " (pr-str version)))
     (when (< (ver/version-compare version min-version) 0)
       (status/die 1
                   "A  minimum version of Clojure %s required.\nFound version: %s"

--- a/script/helper/env.clj
+++ b/script/helper/env.clj
@@ -8,15 +8,11 @@
   "Asserts minimum version of Clojure version"
   []
   (let [min-version "1.10.1.697"
-        result (shell/command {:out :string} "clojure -Sdescribe")
-        _ (.println *err* (str "ret from clojure -Sdescribe: " (pr-str result)))
-        version (->> result
-                     :out
-                     edn/read-string
-                     :version)]
-    (when-not version
-      (throw (ex-info "huh, version is nil" {})))
-    (.println *err* (str "parsed version: " (pr-str version)))
+        version
+        (->> (shell/command {:out :string} "clojure -Sdescribe")
+             :out
+             edn/read-string
+             :version)]
     (when (< (ver/version-compare version min-version) 0)
       (status/die 1
                   "A  minimum version of Clojure %s required.\nFound version: %s"


### PR DESCRIPTION
Of note: native image tests now running under GraalVM 22.3.0. There is now also an experimental JDK19 version of Graal - we'll skip this for now.