### PR TITLE
maint: hack: use focal planck on jammy

### DIFF
--- a/.github/workflows/libs-test.yml
+++ b/.github/workflows/libs-test.yml
@@ -64,9 +64,15 @@ jobs:
 
     - name: Install planck
       run: |
-        sudo add-apt-repository -y ppa:mfikes/planck
-        sudo apt-get update
-        sudo apt-get install -y planck
+        # There are not planck binaries for jammy yet, so hack-around to use focal release
+        sudo add-apt-repository -y "deb http://cz.archive.ubuntu.com/ubuntu focal main universe"
+        sudo add-apt-repository -y "deb http://security.ubuntu.com/ubuntu focal-security main"
+
+        # is missing after installing planck so compensate
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libicu66
+
+        wget https://launchpad.net/~mfikes/+archive/ubuntu/planck/+files/planck_2.25.0-1ppa1~focal1_amd64.deb
+        sudo apt-get install ./planck_2.25.0-1ppa1~focal1_amd64.deb
 
     - name: Install Clojure tools
       uses: DeLaGuardo/setup-clojure@10.1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -98,9 +98,15 @@ jobs:
       if: matrix.os == 'macos'
     - name: Install planck (linux)
       run: |
-        sudo add-apt-repository -y ppa:mfikes/planck
-        sudo apt-get update
-        sudo apt-get install -y planck
+        # There are not planck binaries for jammy yet, so hack-around to use focal release
+        sudo add-apt-repository -y "deb http://cz.archive.ubuntu.com/ubuntu focal main universe"
+        sudo add-apt-repository -y "deb http://security.ubuntu.com/ubuntu focal-security main"
+
+        # is missing after installing planck so compensate
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libicu66
+
+        wget https://launchpad.net/~mfikes/+archive/ubuntu/planck/+files/planck_2.25.0-1ppa1~focal1_amd64.deb
+        sudo apt-get install ./planck_2.25.0-1ppa1~focal1_amd64.deb
       if: matrix.os == 'ubuntu'
 
     #


### PR DESCRIPTION
There are no Ubuntu jammy planck binaries yet.

For now we'll hack around this by using the Ubuntu focal binaries for planck on yammy.

That last official binaries built for planck on ubuntu are v2.25.0. So we are behind the current planck version of v2.27.0. But that's probably fine for now.