### PR TITLE
doc: clarify that stand-alone symbols do not support Clojure's auto-resolve

### DIFF
--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1087,13 +1087,16 @@ a|`'prefix/my-symbol`
 
 |auto-resolved current namespace
 a|`::my-kw`
-a|``my-kw`
+a|n/a ^*^
 
 |auto-resolved namespaced alias
 a|`::my-ns-alias/my-kw`
-a|``my-ns-alias/my-kw` (note: for symbols, if the alias didn't exist, it will be used literally)
+a|n/a ^*^
 
 |===
++
+^*^ _not applicable, stand-alone symbols do not support auto-resolve syntax_
+
 
 * Namespaced keyword and symbols:
 +

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1072,30 +1072,25 @@ If the code you are parsing doesn't use namespaced maps or you have no interest 
 In Clojure keywords and symbols can be qualified.
 A recap via examples:
 
-* Stand-alone keyword and symbols:
+* Stand-alone keywords:
 +
 |===
-| |keyword|symbol
+| |keyword
 
 |unqualified
 a|`:my-kw`
-a|`'my-symbol`
 
 |qualified
 a|`:prefix/my-kw`
-a|`'prefix/my-symbol`
+
 
 |auto-resolved current namespace
 a|`::my-kw`
-a|n/a ^*^
 
 |auto-resolved namespaced alias
 a|`::my-ns-alias/my-kw`
-a|n/a ^*^
 
 |===
-+
-^*^ _not applicable, stand-alone symbols do not support auto-resolve syntax_
 
 
 * Namespaced keyword and symbols:

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1087,11 +1087,11 @@ a|`'prefix/my-symbol`
 
 |auto-resolved current namespace
 a|`::my-kw`
-a|n/a
+a|``my-kw`
 
 |auto-resolved namespaced alias
 a|`::my-ns-alias/my-kw`
-a|n/a
+a|``my-ns-alias/my-kw` (note: for symbols, if the alias didn't exist, it will be used literally)
 
 |===
 


### PR DESCRIPTION
These seem sensible, although it also would make sense to leave them as `n/a` since symbol behavior isn't exactly analogous to that of keywords.

Cheers - V