### PR TITLE
canary tests: 2 new, 1 update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,10 +56,13 @@ Some projects using rewrite-clj v1
 * https://github.com/clojure-lsp/clojure-lsp[clojure-lsp] {canary-tested} - Language Server (LSP) for Clojure
 // repo is not version tagged:
 * https://github.com/mauricioszabo/duck-repled[duck-repled] {not-canary-tested} - Transform your REPL interation into Pathom queries
+// repo is not version tagged:
+* https://github.com/kit-clj/kit[kit] {not-canary-tested} - Lightweight, modular framework for scalable web development in Clojure
 * https://github.com/FiV0/kusonga[kusonga] {canary-tested} - Renaming and moving namespaces in Clojure(script)
 * https://github.com/clojure-emacs/refactor-nrepl[refactor-nrepl] {canary-tested} - nREPL middleware to support refactorings in an editor agnostic way
 * https://github.com/pink-gorilla/reval[reval] {canary-tested} -reproduceable eval - namespace eval and storage with browser ui
 * https://github.com/borkdude/rewrite-edn[rewrite-edn] {canary-tested} - Utility lib on top of rewrite-clj with common operations to update EDN while preserving whitespace and comments
+* https://github.com/matthewdowney/rich-comment-tests[rich-comment-tests] {canary-tested} - Turns rich comment forms into tests
 * https://github.com/lread/test-doc-blocks[test-doc-blocks] {canary-tested} - Test AsciiDoc and CommonMark code blocks found in articles and docstrings
 * https://github.com/nubank/umschreiben-clj[umschreiben-clj] {canary-tested} - Rewrite utilities for refactoring clojure files
 * https://github.com/kkinnear/zprint[zprint] {canary-tested} - Executables, uberjar, and library to beautifully format Clojure and Clojurescript source code and s-expressions

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -279,7 +279,7 @@
             :show-deps-fn lein-deps-tree
             :test-cmds ["lein kaocha"]}
            {:name "antq"
-            :version "2.2.962"
+            :version "2.2.970"
             :platforms [:clj]
             :github-release {:repo "liquidz/antq"}
             :patch-fn deps-edn-v1-patch
@@ -408,6 +408,15 @@
             :patch-fn refactor-nrepl-patch
             :show-deps-fn lein-deps-tree
             :test-cmds ["make test"]}
+           {:name "rich-comment-tests"
+            :version "0.0.4"
+            :platforms [:clj] ;; and bb but we don't test that here
+            :github-release {:repo "matthewdowney/rich-comment-tests"
+                             :version-prefix "v"
+                             :via :tag}
+            :patch-fn deps-edn-v1-patch
+            :show-deps-fn cli-deps-tree
+            :test-cmds ["bb test-clj"]}
            {:name "test-doc-blocks"
             :version "1.0.166-alpha"
             :platforms [:clj :cljs]


### PR DESCRIPTION
new libs using rewrite-clj:
- kit - can add to lib tests if repo starts version tagging
- rich-comment-tests - woot!

new release of existing: antq