### PR TITLE
Fix #214: `node/coerce` + `node/sexpr` roundtrip of regex pattern

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,8 @@ For a list of breaking changes see link:#v1-breaking[breaking changes].
 
 === Unreleased
 
+* Fix `node/coerce` + `node/sexpr` roundtrip of regex pattern https://github.com/clj-commons/rewrite-clj/issues/214[#214] (@borkdude)
+
 === v1.1.46
 
 * added new `rewrite-clj.zip` functions `of-string*` and `of-file*`, these are versions of `of-string` and `of-file` that do no auto-navigation

--- a/src/rewrite_clj/node/coercer.cljc
+++ b/src/rewrite_clj/node/coercer.cljc
@@ -96,7 +96,7 @@
    - includes all lines even if empty
    - behaves the same on clj and cljs"
   [s]
-  (loop [s (string/escape s {\" "\\\""})
+  (loop [s s
          lines []]
     (if-let [m (first (re-find #"(\r\n|\r|\n)" s))]
       (let [eol-ndx (string/index-of s m)]

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -1,6 +1,5 @@
 (ns ^:no-doc rewrite-clj.node.stringz
   (:require [clojure.string :as string]
-            [clojure.tools.reader.edn :as edn]
             [rewrite-clj.node.protocols :as node] ))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -22,10 +21,7 @@
   (node-type [_node] :string)
   (printable-only? [_node] false)
   (sexpr* [_node _opts]
-    (join-lines
-      (map
-        (comp edn/read-string wrap-string)
-        lines)))
+    (join-lines lines))
   (length [_node]
     (+ 2 (reduce + (map count lines))))
   (string [_node]

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -49,6 +49,7 @@
       "\n\n"                 :multi-line :string
       ","                    :token      :string
       "inner\"quote"         :token      :string
+      "\\s+"                 :token      :string
 
       ;; seqs
       []                     :vector     :seq

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -185,7 +185,7 @@
          (is (= ?s (node/string n)))
          (is (= ?sexpr (node/sexpr n))))
     "\"123\""       :token       "123"
-    "\"123\\n456\"" :token       "123\n456"
+    "\"123\\n456\"" :token       "123\\n456"
     "\"123\n456\""  :multi-line  "123\n456"))
 
 (deftest t-parsing-seqs


### PR DESCRIPTION
This manifested in https://github.com/clj-kondo/clj-kondo/issues/1987