### PR TITLE
Fix #214: `node/coerce` + `node/sexpr` roundtrip of regex pattern

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,8 @@ For a list of breaking changes see link:#v1-breaking[breaking changes].
 
 === Unreleased
 
+* Fix `node/coerce` + `node/sexpr` roundtrip of regex pattern https://github.com/clj-commons/rewrite-clj/issues/214[#214] (@borkdude)
+
 === v1.1.46
 
 * added new `rewrite-clj.zip` functions `of-string*` and `of-file*`, these are versions of `of-string` and `of-file` that do no auto-navigation

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -670,7 +670,7 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node lines))
+  [lines] (rewrite-clj.node.stringz/string-node lines lines))
 
 ;; DO NOT EDIT FILE, automatically imported from: rewrite-clj.node.quote
 (defn quote-node

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -670,7 +670,8 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node lines))
+  ([lines] (rewrite-clj.node.stringz/string-node lines))
+  ([lines raw-string] (rewrite-clj.node.stringz/string-node lines raw-string)))
 
 ;; DO NOT EDIT FILE, automatically imported from: rewrite-clj.node.quote
 (defn quote-node

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -670,10 +670,7 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node
-           lines
-           (when (string? lines)
-             lines)))
+  [lines] (rewrite-clj.node.stringz/string-node lines))
 
 ;; DO NOT EDIT FILE, automatically imported from: rewrite-clj.node.quote
 (defn quote-node

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -670,7 +670,10 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node lines lines))
+  [lines] (rewrite-clj.node.stringz/string-node
+           lines
+           (when (string? lines)
+             lines)))
 
 ;; DO NOT EDIT FILE, automatically imported from: rewrite-clj.node.quote
 (defn quote-node

--- a/src/rewrite_clj/node/coercer.cljc
+++ b/src/rewrite_clj/node/coercer.cljc
@@ -96,7 +96,7 @@
    - includes all lines even if empty
    - behaves the same on clj and cljs"
   [s]
-  (loop [s (string/escape s {\" "\\\""})
+  (loop [s s
          lines []]
     (if-let [m (first (re-find #"(\r\n|\r|\n)" s))]
       (let [eol-ndx (string/index-of s m)]
@@ -150,7 +150,7 @@
 (extend-protocol NodeCoerceable
   #?(:clj java.lang.String :cljs string)
   (coerce [v]
-    (string-node (split-to-lines v))))
+    (string-node (split-to-lines v) v)))
 
 #?(:clj
    (extend-protocol NodeCoerceable

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -24,4 +24,7 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node lines lines))
+  [lines] (rewrite-clj.node.stringz/string-node
+           lines
+           (when (string? lines)
+             lines)))

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -24,4 +24,4 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node lines))
+  [lines] (rewrite-clj.node.stringz/string-node lines lines))

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -24,4 +24,5 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node lines))
+  ([lines] (rewrite-clj.node.stringz/string-node lines))
+  ([lines raw-string] (rewrite-clj.node.stringz/string-node lines raw-string)))

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -24,7 +24,4 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines] (rewrite-clj.node.stringz/string-node
-           lines
-           (when (string? lines)
-             lines)))
+  [lines] (rewrite-clj.node.stringz/string-node lines))

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -57,7 +57,11 @@
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
   ```"
-  [lines raw-lines]
-  (if (string? lines)
-    (->StringNode [lines] raw-lines)
-    (->StringNode lines raw-lines)))
+  ([lines]
+   (if (string? lines)
+     (->StringNode [lines] lines)
+     (->StringNode lines nil)))
+  ([lines raw-string]
+   (if (string? lines)
+     (->StringNode [lines] raw-string)
+     (->StringNode lines raw-string))))

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -31,7 +31,7 @@
   (length [_node]
     (+ 2 (reduce + (map count lines))))
   (string [_node]
-    (wrap-string (join-lines lines)))
+    (wrap-string (or raw-lines (join-lines lines))))
 
   Object
   (toString [node]

--- a/src/rewrite_clj/parser/string.cljc
+++ b/src/rewrite_clj/parser/string.cljc
@@ -34,8 +34,7 @@
 
 (defn parse-string
   [#?(:cljs ^not-native reader :default reader)]
-  (let [data (read-string-data reader)]
-    (nstring/string-node data)))
+  (nstring/string-node (read-string-data reader)))
 
 (defn parse-regex
   [#?(:cljs ^not-native reader :default reader)]

--- a/src/rewrite_clj/parser/string.cljc
+++ b/src/rewrite_clj/parser/string.cljc
@@ -34,7 +34,8 @@
 
 (defn parse-string
   [#?(:cljs ^not-native reader :default reader)]
-  (nstring/string-node (read-string-data reader)))
+  (let [data (read-string-data reader)]
+    (nstring/string-node data nil)))
 
 (defn parse-regex
   [#?(:cljs ^not-native reader :default reader)]

--- a/src/rewrite_clj/parser/string.cljc
+++ b/src/rewrite_clj/parser/string.cljc
@@ -35,7 +35,7 @@
 (defn parse-string
   [#?(:cljs ^not-native reader :default reader)]
   (let [data (read-string-data reader)]
-    (nstring/string-node data nil)))
+    (nstring/string-node data)))
 
 (defn parse-regex
   [#?(:cljs ^not-native reader :default reader)]

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -49,6 +49,7 @@
       "\n\n"                 :multi-line :string
       ","                    :token      :string
       "inner\"quote"         :token      :string
+      "\\s+"                 :token      :string
 
       ;; seqs
       []                     :vector     :seq
@@ -66,7 +67,7 @@
   (testing "multi-line string newline variants are normalized"
     (let [s "hey\nyou\rover\r\nthere"
           n (node/coerce s)]
-      (is (= "hey\nyou\nover\nthere" (node/sexpr n))))))
+      (is (= s (node/sexpr n))))))
 
 (deftest
   t-quoted-list-reader-location-metadata-elided

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -64,10 +64,12 @@
 
       ;; date
       #inst "2014-11-26T00:05:23" :token :token))
-  (testing "multi-line string newline variants are normalized"
+  (testing "multi-line string newline variants are preserved"
     (let [s "hey\nyou\rover\r\nthere"
           n (node/coerce s)]
-      (is (= s (node/sexpr n))))))
+      (is (= s (node/sexpr n)))))
+  (testing "coerce string roundtrip"
+    (is (= "\"hey \\\" man\"" (-> "hey \" man" node/coerce node/string)))))
 
 (deftest
   t-quoted-list-reader-location-metadata-elided


### PR DESCRIPTION
This is an alternative solution to #214 which is less risky and leaves the other behavior in place