### PR TITLE
Fix coerce/sexpr roundtrip for `"\\s+"`

### DIFF
--- a/src/rewrite_clj/node/coercer.cljc
+++ b/src/rewrite_clj/node/coercer.cljc
@@ -96,7 +96,8 @@
    - includes all lines even if empty
    - behaves the same on clj and cljs"
   [s]
-  (loop [s (string/escape s {\" "\\\""})
+  (loop [s (string/escape s {\" "\\\""
+                             \\ "\\\\"})
          lines []]
     (if-let [m (first (re-find #"(\r\n|\r|\n)" s))]
       (let [eol-ndx (string/index-of s m)]

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -49,6 +49,7 @@
       "\n\n"                 :multi-line :string
       ","                    :token      :string
       "inner\"quote"         :token      :string
+      "\\s+"                 :token      :string
 
       ;; seqs
       []                     :vector     :seq

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -67,7 +67,9 @@
   (testing "multi-line string newline variants are normalized"
     (let [s "hey\nyou\rover\r\nthere"
           n (node/coerce s)]
-      (is (= "hey\nyou\nover\nthere" (node/sexpr n))))))
+      (is (= "hey\nyou\nover\nthere" (node/sexpr n)))))
+  (testing "coerce string roundtrip"
+    (is (= "\"hey \\\" man\"" (-> "hey \" man" node/coerce node/string)))))
 
 (deftest
   t-quoted-list-reader-location-metadata-elided


### PR DESCRIPTION
A third alternative.

Probably not what we want to do long term, but addresses the problem in the short term with seemingly little risk.

Closes #214