### PR TITLE
Revert to v0 behaviour for string coercion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,22 @@ For a list of breaking changes see link:#v1-breaking[breaking changes].
 
 === Unreleased
 
+* Clojure string to rewrite-clj node coercion fixes
+https://github.com/clj-commons/rewrite-clj/issues/214[#214]
+(@borkdude/@lread collab)
+** `"a\n\b\r\nc"` is now preserved as is.
+It was being coerced to:
++
+[source,clojure]
+----
+"a
+b
+c"
+----
+** escaped characters now coerce correctly.
+Previously we were only handling `\"`.
+Strings like `"\\s+"` now handled and preserved.
+
 === v1.1.46
 
 * added new `rewrite-clj.zip` functions `of-string*` and `of-file*`, these are versions of `of-string` and `of-file` that do no auto-navigation

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -690,8 +690,9 @@
   This function was originally written to serve the rewrite-clj parser.
   Escaping and wrapping expectations are non-obvious.
   - characters within strings are assumed to be escaped
-  - the string should not wrapped with `\\\"`
+  - but the string should not wrapped with `\\\"`
 
+  Here's an example of conforming to these expectations.
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
   ```Clojure

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -657,7 +657,7 @@
 (defn string-node
   "Create node representing a string value where `lines` can be a sequence of strings or a single string.
 
-  When `lines` is a sequence, the resulting node will `tag` will be `:multi-line`, otherwise `:token`.
+  When `lines` is a sequence, the resulting node `tag` will be `:multi-line`, otherwise `:token`.
 
   `:multi-line` refers to a single string in your source that appears over multiple lines, for example:
 
@@ -689,8 +689,8 @@
 
   This function was originally written to serve the rewrite-clj parser.
   Escaping and wrapping expectations are non-obvious.
-  Characters within strings are assumed to be escaped, but not wrapped with `\\\"`
-  Neglecting to escape characters that require escaping will result in invalid strings.
+  - characters within strings are assumed to be escaped
+  - the string should not wrapped with `\\\"`
 
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
@@ -707,7 +707,7 @@
   ;; => \"\\\"hey \\\\\\\" man\\\"\"
   ```
 
-  For single-line strings consider [[token-node]].
+  To construct strings appearing on a single line, consider [[token-node]].
   It will handle escaping for you."
   [lines] (rewrite-clj.node.stringz/string-node lines))
 
@@ -812,7 +812,7 @@
    ;; => \"\\\"astring\\\"\"
    ```
 
-   For strings appearing over multiple lines, see [[string-node]]."
+   To construct strings appearing over multiple lines, see [[string-node]]."
   ([value] (rewrite-clj.node.token/token-node value))
   ([value string-value] (rewrite-clj.node.token/token-node value string-value)))
 

--- a/src/rewrite_clj/node.cljc
+++ b/src/rewrite_clj/node.cljc
@@ -692,7 +692,7 @@
   - characters within strings are assumed to be escaped
   - but the string should not wrapped with `\\\"`
 
-  Here's an example of conforming to these expectations.
+  Here's an example of conforming to these expectations for a string that has escape sequences.
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
   ```Clojure

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -46,7 +46,7 @@
   - characters within strings are assumed to be escaped
   - but the string should not wrapped with `\\\"`
 
-  Here's an example of conforming to these expectations.
+  Here's an example of conforming to these expectations for a string that has escape sequences.
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
   ```Clojure

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -11,7 +11,7 @@
 (defn string-node
   "Create node representing a string value where `lines` can be a sequence of strings or a single string.
 
-  When `lines` is a sequence, the resulting node will `tag` will be `:multi-line`, otherwise `:token`.
+  When `lines` is a sequence, the resulting node `tag` will be `:multi-line`, otherwise `:token`.
 
   `:multi-line` refers to a single string in your source that appears over multiple lines, for example:
 
@@ -43,8 +43,8 @@
 
   This function was originally written to serve the rewrite-clj parser.
   Escaping and wrapping expectations are non-obvious.
-  Characters within strings are assumed to be escaped, but not wrapped with `\\\"`
-  Neglecting to escape characters that require escaping will result in invalid strings.
+  - characters within strings are assumed to be escaped
+  - the string should not wrapped with `\\\"`
 
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
@@ -61,6 +61,6 @@
   ;; => \"\\\"hey \\\\\\\" man\\\"\"
   ```
 
-  For single-line strings consider [[token-node]].
+  To construct strings appearing on a single line, consider [[token-node]].
   It will handle escaping for you."
   [lines] (rewrite-clj.node.stringz/string-node lines))

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -44,8 +44,9 @@
   This function was originally written to serve the rewrite-clj parser.
   Escaping and wrapping expectations are non-obvious.
   - characters within strings are assumed to be escaped
-  - the string should not wrapped with `\\\"`
+  - but the string should not wrapped with `\\\"`
 
+  Here's an example of conforming to these expectations.
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
   ```Clojure

--- a/src/rewrite_clj/node/string.clj
+++ b/src/rewrite_clj/node/string.clj
@@ -13,6 +13,22 @@
 
   When `lines` is a sequence, the resulting node will `tag` will be `:multi-line`, otherwise `:token`.
 
+  `:multi-line` refers to a single string in your source that appears over multiple lines, for example:
+
+  ```Clojure
+  (def s \"foo
+            bar
+              baz\")
+  ```
+
+  It does not apply to a string that appears on a single line that includes escaped newlines, for example:
+
+  ```Clojure
+  (def s \"foo\\nbar\\n\\baz\")
+  ```
+
+  Naive examples (see example on escaping below):
+
   ```Clojure
   (require '[rewrite-clj.node :as n])
 
@@ -23,5 +39,28 @@
   (-> (n/string-node [\"line1\" \"\" \"line3\"])
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
-  ```"
+  ```
+
+  This function was originally written to serve the rewrite-clj parser.
+  Escaping and wrapping expectations are non-obvious.
+  Characters within strings are assumed to be escaped, but not wrapped with `\\\"`
+  Neglecting to escape characters that require escaping will result in invalid strings.
+
+  (Best to view this on cljdoc, docstring string escaping is confusing).
+
+  ```Clojure
+  (require '[clojure.string :as string])
+
+  (defn pr-str-unwrapped [s]
+    (apply str (-> s pr-str next butlast)))
+
+  (-> \"hey \\\" man\"
+      pr-str-unwrapped
+      n/string-node
+      n/string)
+  ;; => \"\\\"hey \\\\\\\" man\\\"\"
+  ```
+
+  For single-line strings consider [[token-node]].
+  It will handle escaping for you."
   [lines] (rewrite-clj.node.stringz/string-node lines))

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -77,7 +77,7 @@
   - characters within strings are assumed to be escaped
   - but the string should not wrapped with `\\\"`
 
-  Here's an example of conforming to these expectations.
+  Here's an example of conforming to these expectations for a string that has escape sequences.
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
   ```Clojure

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -44,6 +44,22 @@
 
   When `lines` is a sequence, the resulting node will `tag` will be `:multi-line`, otherwise `:token`.
 
+  `:multi-line` refers to a single string in your source that appears over multiple lines, for example:
+
+  ```Clojure
+  (def s \"foo
+            bar
+              baz\")
+  ```
+
+  It does not apply to a string that appears on a single line that includes escaped newlines, for example:
+
+  ```Clojure
+  (def s \"foo\\nbar\\n\\baz\")
+  ```
+
+  Naive examples (see example on escaping below):
+
   ```Clojure
   (require '[rewrite-clj.node :as n])
 
@@ -54,7 +70,30 @@
   (-> (n/string-node [\"line1\" \"\" \"line3\"])
        n/string)
   ;; => \"\\\"line1\\n\\nline3\\\"\"
-  ```"
+  ```
+
+  This function was originally written to serve the rewrite-clj parser.
+  Escaping and wrapping expectations are non-obvious.
+  Characters within strings are assumed to be escaped, but not wrapped with `\\\"`
+  Neglecting to escape characters that require escaping will result in invalid strings.
+
+  (Best to view this on cljdoc, docstring string escaping is confusing).
+
+  ```Clojure
+  (require '[clojure.string :as string])
+
+  (defn pr-str-unwrapped [s]
+    (apply str (-> s pr-str next butlast)))
+
+  (-> \"hey \\\" man\"
+      pr-str-unwrapped
+      n/string-node
+      n/string)
+  ;; => \"\\\"hey \\\\\\\" man\\\"\"
+  ```
+
+  For single-line strings consider [[token-node]].
+  It will handle escaping for you."
   [lines]
   (if (string? lines)
     (->StringNode [lines])

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -42,7 +42,7 @@
 (defn string-node
   "Create node representing a string value where `lines` can be a sequence of strings or a single string.
 
-  When `lines` is a sequence, the resulting node will `tag` will be `:multi-line`, otherwise `:token`.
+  When `lines` is a sequence, the resulting node `tag` will be `:multi-line`, otherwise `:token`.
 
   `:multi-line` refers to a single string in your source that appears over multiple lines, for example:
 
@@ -74,8 +74,8 @@
 
   This function was originally written to serve the rewrite-clj parser.
   Escaping and wrapping expectations are non-obvious.
-  Characters within strings are assumed to be escaped, but not wrapped with `\\\"`
-  Neglecting to escape characters that require escaping will result in invalid strings.
+  - characters within strings are assumed to be escaped
+  - the string should not wrapped with `\\\"`
 
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
@@ -92,7 +92,7 @@
   ;; => \"\\\"hey \\\\\\\" man\\\"\"
   ```
 
-  For single-line strings consider [[token-node]].
+  To construct strings appearing on a single line, consider [[token-node]].
   It will handle escaping for you."
   [lines]
   (if (string? lines)

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -75,8 +75,9 @@
   This function was originally written to serve the rewrite-clj parser.
   Escaping and wrapping expectations are non-obvious.
   - characters within strings are assumed to be escaped
-  - the string should not wrapped with `\\\"`
+  - but the string should not wrapped with `\\\"`
 
+  Here's an example of conforming to these expectations.
   (Best to view this on cljdoc, docstring string escaping is confusing).
 
   ```Clojure

--- a/src/rewrite_clj/node/token.cljc
+++ b/src/rewrite_clj/node/token.cljc
@@ -79,7 +79,12 @@
 
    (-> (n/token-node 42) n/string)
    ;; => \"42\"
-   ```"
+
+   (-> (n/token-node \"astring\") n/string)
+   ;; => \"\\\"astring\\\"\"
+   ```
+
+   For strings appearing over multiple lines, see [[string-node]]."
   ([value]
    (token-node value (pr-str value)))
   ([value string-value]

--- a/src/rewrite_clj/node/token.cljc
+++ b/src/rewrite_clj/node/token.cljc
@@ -84,7 +84,7 @@
    ;; => \"\\\"astring\\\"\"
    ```
 
-   For strings appearing over multiple lines, see [[string-node]]."
+   To construct strings appearing over multiple lines, see [[string-node]]."
   ([value]
    (token-node value (pr-str value)))
   ([value string-value]

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -41,14 +41,14 @@
       ::1.5.1                :token      :keyword
       :namespace/keyword     :token      :keyword
 
-      ""                     :token      :string
-      "hello, over there!"   :token      :string
-      "multi\nline"          :multi-line :string
-      " "                    :token      :string
-      "\n"                   :multi-line :string
-      "\n\n"                 :multi-line :string
-      ","                    :token      :string
-      "inner\"quote"         :token      :string
+      ""                     :token      :token
+      "hello, over there!"   :token      :token
+      "multi\nline"          :token      :token
+      " "                    :token      :token
+      "\n"                   :token      :token
+      "\n\n"                 :token      :token
+      ","                    :token      :token
+      "inner\"quote"         :token      :token
 
       ;; seqs
       []                     :vector     :seq
@@ -63,10 +63,10 @@
 
       ;; date
       #inst "2014-11-26T00:05:23" :token :token))
-  (testing "multi-line string newline variants are normalized"
+  (testing "multi-line string newline variants are preserved"
     (let [s "hey\nyou\rover\r\nthere"
           n (node/coerce s)]
-      (is (= "hey\nyou\nover\nthere" (node/sexpr n)))))
+      (is (= s (node/sexpr n)))))
   (testing "coerce string roundtrip"
     (is (= "\"hey \\\" man\"" (-> "hey \" man" node/coerce node/string)))))
 

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -49,6 +49,7 @@
       "\n\n"                 :token      :token
       ","                    :token      :token
       "inner\"quote"         :token      :token
+      "\\s+"                 :token      :token
 
       ;; seqs
       []                     :vector     :seq


### PR DESCRIPTION
As in v0, strings are once again coerced to token nodes (instead of string nodes).

Effective fixes for coerced strings:
1. character escaping handled automatically
2. string `"a\nb\nc"` is no longer interpreted as a string appearing on multiple lines.

Bring some clarity to rewrite-clj.node/string-node's usage and
expectations via its docstring.

Alternative to PRs #216 and #217.

Fixes #214