### PR TITLE
tests: no longer need to install karma-cli

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -156,16 +156,6 @@ jobs:
         planck --version
       if: matrix.os != 'windows'
 
-    #
-    # Node modules
-    #
-    - name: Install karma command line (windows)
-      run: npm install karma-cli -g
-      if: matrix.os == 'windows'
-    - name: Install karma command line (macos, linux)
-      run: sudo npm install karma-cli -g
-      if: matrix.os != 'windows'
-
     - name: Install node modules
       run: npm install
 

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -67,7 +67,6 @@ After checking out this project from GitHub,
 1. Install JavaScript libraries and tools required by https://github.com/bensu/doo[doo] and https://github.com/thheller/shadow-cljs[shadow-cljs]:
 +
 ----
-sudo npm install karma-cli -g
 npm install
 ----
 

--- a/script/test_cljs.clj
+++ b/script/test_cljs.clj
@@ -22,7 +22,8 @@
    :source-map (= "none" optimizations)})
 
 (defn doo-opts [test-combo]
-  {:karma
+  {:paths {:karma "npx karma"}
+   :karma
    {:config {"plugins" ["karma-spec-reporter" "karma-junit-reporter"]
              "reporters" ["spec" "junit"]
              "specReporter" {"suppressSkipped" "false"


### PR DESCRIPTION
Our cljs browser tests are run via cljs-test-runner which uses doo. Doo docs recommended installing karma-cli globally.

karma-cli makes the karma command effectively visible on the PATH.

But we can tell clj-test-runner to tell doo to run karma via `npx karma` instead. This way we invoke our locally installed karma without this karma-cli dependency.

Might fix #224.

Regardless, seems like an improvement to have one less dev setup step and one less npm install.