### PR TITLE
maint: bump GraalVM to current release

### DIFF
--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          version: '22.3.1'
+          version: '22.3.2'
           java-version: ${{ matrix.graal-java }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -20,7 +20,7 @@ Automated testing is setup using GraalVM v22 JDK11.
 * Clojure v1.10.1.697 or above for `clojure` command
 ** Note that rewrite-clj v1 itself supports Clojure v1.8 and above
 * Babashka v0.3.7 or above
-* GraalVM v22.3.0 JDK 11 or 17 (if you want to run GraalVM native image tests)
+* GraalVM v22.3.2 JDK 11 or 17 (if you want to run GraalVM native image tests)
 
 === Windows Notes
 


### PR DESCRIPTION
We use GraalVM to test that rewrite-clj works, and continues to work, as an executable created by native-image.