### PR TITLE
Typo fix: `subedit->>` docstring

### DIFF
--- a/src/rewrite_clj/zip/subedit.cljc
+++ b/src/rewrite_clj/zip/subedit.cljc
@@ -95,7 +95,7 @@
   `(subedit-node ~zloc #(-> % ~@body)))
 
 (defmacro subedit->>
-  "Like `->`. Threads `zloc`, as an isolated sub-tree through forms, then zips
+  "Like `->>`. Threads `zloc`, as an isolated sub-tree through forms, then zips
       up to, and locates at, the root of the modified sub-tree.
 
    See [docs on sub editing](/doc/01-user-guide.adoc#sub-editing)."


### PR DESCRIPTION
Function is analogous to thread-last, but had `->` in docstring