### PR TITLE
test: bump GraalVM JDK to 21

### DIFF
--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, ubuntu, macos ]
-        java-version: [ '17.0.8', '20.0.2' ]
+        java-version: [ '21' ]
         test: [ native, native-sci ]
         clojure-version: [ '1.11' ]
 

--- a/deps.edn
+++ b/deps.edn
@@ -114,8 +114,8 @@
 
 
            :sci-test {:extra-paths ["target/generated/sci-test/src"]
-                      :extra-deps {lread/sci-test_{:git/url "https://github.com/lread/sci-test.git"
-                                                   :sha "78e098353d5cce878b8aec1767ae290a3d2fcee9"}}}
+                      :extra-deps {lread/sci-test {:git/url "https://github.com/lread/sci-test.git"
+                                                   :sha "4323578406848180424a801018047fe859e72c4b"}}}
 
            :native-test {:extra-paths ["target/generated/graal"]}
 

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -12,7 +12,7 @@ We make use of planck for cljs bootstrap (aka cljs self-hosted) testing.
 Planck is currently not available for Windows.
 
 We test that rewrite-clj operates as expected when natively compile via GraalVM.
-Automated testing is setup using GraalVM JDK 17 and JDK 20.
+Automated testing is setup using GraalVM JDK 21.
 At this time we only test against the Community Edition.
 
 == Prerequisites
@@ -21,7 +21,7 @@ At this time we only test against the Community Edition.
 * Clojure v1.10.1.697 or above for `clojure` command
 ** Note that rewrite-clj v1 itself supports Clojure v1.8 and above
 * Babashka v0.3.7 or above
-* Current release of GraalVM JDK 17 or 20, if you want to run GraalVM native image tests
+* Current release of GraalVM JDK 21, if you want to run GraalVM native image tests
 
 === Windows Notes
 

--- a/script/helper/graal.clj
+++ b/script/helper/graal.clj
@@ -19,7 +19,7 @@
           version-out (->> (shell/command {:err :string} java-exe "-version")
                            :err)
           [actual-graal-major actual-jdk-major] (->> version-out
-                                       (re-find #"(?i)GraalVM(?: CE)? (\d+)\..*\(build (\d+)\.")
+                                       (re-find #"(?i)GraalVM(?: CE)? (\d+).*\(build (\d+)")
                                        rest
                                        (map parse-long))]
       (cond


### PR DESCRIPTION
Drop testing for GraalVM JDK 17 and 20.

GraalVM JDK 21 returns version as major-only, which is a bit odd. Had to adjust some version parsing here and in sci-test.