### PR TITLE
bump org.clojure/tools.reader to version 1.3.7

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,8 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 === Unreleased
 
+* bump `org.clojure/tools.reader` to version `1.3.7`
+
 === v1.1.47 - 2023-03-25 [[v1.1.47]]
 
 * Clojure string to rewrite-clj node coercion fixes

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps {org.clojure/clojure {:mvn/version "1.8.0"}
-        org.clojure/tools.reader {:mvn/version "1.3.6"}}
+        org.clojure/tools.reader {:mvn/version "1.3.7"}}
 
  :aliases {;; we use babashka/neil for project attributes
            ;; publish workflow references these values (and automatically bumps patch component of version)

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -157,7 +157,7 @@
  (patch-deps {:filename (str (fs/file home-dir "project.clj"))
               ;; we remove and add tools.reader because project.clj has pedantic? :abort enabled
               :removals #{'rewrite-clj 'org.clojure/tools.reader}
-              :additions [['org.clojure/tools.reader "1.3.6"]
+              :additions [['org.clojure/tools.reader "1.3.7"]
                           ['rewrite-clj rewrite-clj-version]]}))
 
 ;;
@@ -193,7 +193,7 @@
         (string/replace #"rewrite-clj \"(\d+\.)+.*\""
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.3.6\"")
+                        "org.clojure/tools.reader \"1.3.7\"")
         (->> (spit p)))))
 
 ;;

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -225,6 +225,9 @@
         ;; done with exercising my rewrite-clj skills for now! :-)
         (string/replace #"rewrite-clj \"(\d+\.)+.*\""
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
+        ;; pedantic is enabled for CI, so adjust to match rewrite-clj so we don't fail
+        (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
+                        "org.clojure/tools.reader \"1.3.7\"")
         (->> (spit p)))))
 
 ;;


### PR DESCRIPTION
This is a rewrite-clj dep and will be picked up by users of rewrite-clj.