### PR TITLE
tests & ci: Add Clojure 1.12 alpha

### DIFF
--- a/.github/workflows/libs-test.yml
+++ b/.github/workflows/libs-test.yml
@@ -51,6 +51,14 @@ jobs:
           clj-cache-prefix: clj-libs-deps-${{ matrix.lib-name }}
           clj-cache-hash-files: "'script/test_libs.clj','deps.edn','bb.edn'"
 
+      ## Lein version > 2.10.0 is causing refactor-nrepl to fail, so explicitly install a version that works
+      ## instead of using lein bundled with github actions image.
+      ## Upcoming 2.11.2 might fix, can optionally revisit in the future.
+      - name: Install Lein
+        uses: DeLaGuardo/setup-clojure@12.4
+        with:
+          lein: 2.10.0
+
       - name: Install Planck
         uses: ./.github/workflows/setup-planck
         if: contains( matrix.requires, 'planck' )

--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ windows, ubuntu, macos ]
         java-version: [ '21.0.1' ]
         test: [ native, native-sci ]
-        clojure-version: [ '1.11' ]
+        clojure-version: [ '1.11', '1.12' ]
 
     name: ${{ matrix.os }},jdk${{ matrix.java-version }},${{ matrix.test }},clj${{ matrix.clojure-version }}
 

--- a/.github/workflows/shared-setup/action.yml
+++ b/.github/workflows/shared-setup/action.yml
@@ -23,7 +23,7 @@ runs:
 
   steps:
     - name: Clojure deps cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository
@@ -33,7 +33,7 @@ runs:
         restore-keys: ${{ runner.os }}-${{ inputs.clj-cache-prefix }}
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.jdk }}

--- a/.github/workflows/shared-setup/action.yml
+++ b/.github/workflows/shared-setup/action.yml
@@ -40,7 +40,7 @@ runs:
       if: inputs.jdk != 'skip'
 
     - name: Install Babashka
-      uses: DeLaGuardo/setup-clojure@10.1
+      uses: DeLaGuardo/setup-clojure@12.4
       with:
         bb: 'latest'
 
@@ -54,7 +54,7 @@ runs:
       if: runner.os == 'Windows'
 
     - name: Install Clojure (macos, linux)
-      uses: DeLaGuardo/setup-clojure@10.1
+      uses: DeLaGuardo/setup-clojure@12.4
       with:
         cli: 'latest'
       if: runner.os != 'Windows'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -60,7 +60,7 @@ jobs:
         if: contains( matrix.requires, 'planck' )
 
       - name: Node modules cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/bb.edn
+++ b/bb.edn
@@ -20,7 +20,7 @@
          lint              {:task lint/-main              :doc "[--rebuild] lint source code using clj-kondo, eastwood"}
          -lint-kondo       {:task lint-kondo/-main        :doc "[--rebuild]"}
          -lint-eastwood    {:task lint-eastwood/-main}
-         test-clj          {:task test-clj/-main          :doc "[--clojure-version (1.8|1.9|1.10|1.11)]"}
+         test-clj          {:task test-clj/-main          :doc "[--clojure-version (1.8|1.9|1.10|1.11|1.12)]"}
          test-cljs         {:task test-cljs/-main         :doc "use --help for args"}
          test-shadow-cljs  {:task test-shadow-cljs/-main}
          test-native       {:task test-native/-main       :doc "run rewrite-clj and tests after both compiled with GraalVM native-image"}

--- a/deps.edn
+++ b/deps.edn
@@ -18,6 +18,9 @@
            :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
 
+           ;; Clojure pre-release to test against
+           :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha7"}}}
+
            ;;
            ;; ClojureScript version we test with (and support)
            ;;

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -5,7 +5,7 @@
             [helper.shell :as shell]
             [lread.status-line :as status]))
 
-(def allowed-clojure-versions '("1.8" "1.9" "1.10" "1.11"))
+(def allowed-clojure-versions '("1.8" "1.9" "1.10" "1.11" "1.12"))
 
 (defn run-unit-tests [clojure-version]
   (status/line :head (str "testing clojure source against clojure v" clojure-version))
@@ -28,7 +28,7 @@
 (def args-usage "Valid args: [options]
 
 Options:
-  -v, --clojure-version VERSION  Test with Clojure [1.8, 1.9, 1.10, 1.11 all] [default: 1.8]
+  -v, --clojure-version VERSION  Test with Clojure [1.8, 1.9, 1.10, 1.11, 1.12 all] [default: 1.8]
   --help                         Show this help")
 
 (defn -main [& args]

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -393,7 +393,7 @@
             :show-deps-fn cli-deps-tree
             :test-cmds ["clojure -M:test"]}
            {:name "refactor-nrepl"
-            :version "3.9.0"
+            :version "3.9.1"
             :platforms [:clj]
             :github-release {:repo "clojure-emacs/refactor-nrepl"
                              :via :tag

--- a/script/test_native.clj
+++ b/script/test_native.clj
@@ -17,12 +17,12 @@
                  "-m" "clj-graal.gen-test-runner"
                  "--dest-dir" dir "test-by-namespace"))
 
-(def allowed-clojure-versions '("1.10" "1.11"))
+(def allowed-clojure-versions '("1.10" "1.11" "1.12"))
 
 (def args-usage "Valid args: [options]
 
 Options:
-  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11] [default: 1.11]
+  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11, 1.12] [default: 1.11]
   --help                         Show this help")
 
 

--- a/script/test_native_sci.clj
+++ b/script/test_native_sci.clj
@@ -24,12 +24,12 @@
     (status/die 1 "native image %s not found." exe-fname))
   (shell/command exe-fname "--file" "script/sci_test_runner.clj" "--classpath" "test"))
 
-(def allowed-clojure-versions '("1.10" "1.11"))
+(def allowed-clojure-versions '("1.10" "1.11" "1.12"))
 
 (def args-usage "Valid args: [options]
 
 Options:
-  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11] [default: 1.11]
+  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11, 1.12] [default: 1.11]
   --help                         Show this help")
 
 


### PR DESCRIPTION
Clojure 1.12 alpha is mature enough to test against it.

No changes to tests, will handle new meta syntax separately.