### PR TITLE
test & ci: bump deps, canary test clj-mergetool

### DIFF
--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))

--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, ubuntu, macos ]
-        java-version: [ '22' ]
+        java-version: [ '22.0.1' ]
         test: [ native, native-sci ]
         clojure-version: [ '1.11', '1.12' ]
 

--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,7 @@ Some projects using rewrite-clj v1
 // no unit tests:
 * https://github.com/lambdaisland/classpath[classpath] {not-canary-tested} - Classpath/classloader/deps.edn related utilities
 * https://github.com/nextjournal/clerk[clerk] {canary-tested} - Local-First Notebooks for Clojure
+* https://github.com/kurtharriger/clj-mergetool[clj-mergetool] {canary-tested} - Smarter git mergetool for clojure and edn
 * https://github.com/weavejester/cljfmt[cljfmt] {canary-tested} - A tool for formatting Clojure code
 * https://github.com/greglook/cljstyle[cljstyle] {canary-tested} - A tool for formatting Clojure code
 * https://github.com/clojure-lsp/clojure-lsp[clojure-lsp] {canary-tested} - Language Server (LSP) for Clojure

--- a/bb.edn
+++ b/bb.edn
@@ -8,7 +8,7 @@
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         etaoin/etaoin {:mvn/version "1.0.40"}
-        io.github.babashka/neil {:git/tag "v0.2.63" :git/sha "076fb83"}}
+        io.github.babashka/neil {:git/tag "v0.3.65" :git/sha "9a79582"}}
  :tasks {;; setup
          :requires ([clojure.string :as string]
                     [lread.status-line :as status])

--- a/deps.edn
+++ b/deps.edn
@@ -101,7 +101,7 @@
                                  cli-matic/cli-matic {:mvn/version "0.5.4"}}}
 
            :apply-import-vars {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
-                               :extra-deps {metosin/malli {:mvn/version "0.15.0"}
+                               :extra-deps {metosin/malli {:mvn/version "0.16.0"}
                                             io.aviso/pretty {:mvn/version "1.4.4"}}
                                :ns-default lread.apply-import-vars}
 
@@ -147,12 +147,13 @@
            ;;
            ;; Maintenance support
            ;;
-           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.8.1185"}
-                                   org.slf4j/slf4j-simple {:mvn/version "2.0.12"} ;; to rid ourselves of logger warnings
+           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.8.1194"}
+                                   org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
                                    }
                       :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
                       :main-opts ["-m" "antq.core"
                                   "--ignore-locals"
+                                  "--exclude=lambdaisland/kaocha@1.88.1376" ;; breaks clojure 1.9 compat, let's wait to see if that was intentional
                                   "--exclude=lambdaisland/kaocha@1.0.829" ;; https://github.com/lambdaisland/kaocha/issues/208
                                   "--exclude=com.bhauman/figwheel-main@0.2.15" ;; deployment was botched, some components missing
                                   "--exclude=org.clojure/clojurescript@1.11.121" ;; no evidence yet that this is an official release

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "karma-cljs-test": "^0.1.0",
         "karma-junit-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
-        "shadow-cljs": "^2.28.2"
+        "shadow-cljs": "^2.28.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.1.tgz",
+      "integrity": "sha512-dzJtaDAAoXx4GCOJpbB2eG/Qj8VDpdwkLsWGzGm+0L7E8/434RyMbAHmk9ubXWVAb9nXmc44jUf8GKqVDiKezg==",
       "dev": true
     },
     "node_modules/@types/cookie": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.28.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.28.2.tgz",
-      "integrity": "sha512-Tr/8KyPbJgOn3O32EEaxA4Zm7S/ey/mbH4O+qtyV10dMaTPrZh0/RTPzsvtRubwEi1nnTTCo+YoC9yVp13tdEA==",
+      "version": "2.28.3",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.28.3.tgz",
+      "integrity": "sha512-nHu6hDPp3sysa7vj8/b867XvpluEGS8tbUBz47KPgIVCOhcVExXrlKCCg+JRWUh9IY9VdrO1sLqr0dil8cJSDQ==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -2512,9 +2512,9 @@
       }
     },
     "node_modules/url/node_modules/qs": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.0.tgz",
-      "integrity": "sha512-trVZiI6RMOkO476zLGaBIzszOdFPnCCXHPG9kn0yuS1uz6xdVxPfZdB3vUig9pxPFDM9BRAgz/YUIVQ1/vuiUg==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "karma-cljs-test": "^0.1.0",
     "karma-junit-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
-    "shadow-cljs": "^2.28.2"
+    "shadow-cljs": "^2.28.3"
   }
 }

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -272,7 +272,7 @@
             :show-deps-fn lein-deps-tree
             :test-cmds ["lein kaocha"]}
            {:name "antq"
-            :version "2.8.1185"
+            :version "2.8.1194"
             :platforms [:clj]
             :github-release {:repo "liquidz/antq"}
             :patch-fn deps-edn-v1-patch
@@ -295,6 +295,13 @@
             :patch-fn deps-edn-v1-patch
             :show-deps-fn cli-deps-tree
             :test-cmds ["bb test:clj :kaocha/reporter '[kaocha.report/documentation]'"]}
+           {:name "clj-mergetool"
+            :version "0.2.1"
+            :platforms [:clj]
+            :github-release {:repo "kurtharriger/clj-mergetool"}
+            :patch-fn deps-edn-v1-patch
+            :show-deps-fn cli-deps-tree
+            :test-cmds ["clojure -T:build test"]}
            {:name "cljfmt"
             :version "0.12.0"
             :platforms [:clj :cljs]
@@ -315,7 +322,7 @@
                         "bin/test unit"]}
            {:name "clojure-lsp"
             :platforms [:clj]
-            :version "2024.03.13-13.11.00"
+            :version "2024.03.31-19.10.13"
             :github-release {:repo "clojure-lsp/clojure-lsp"}
             :patch-fn clojure-lsp-patch
             :show-deps-fn clojure-lsp-deps
@@ -384,7 +391,7 @@
             :show-deps-fn cli-deps-tree
             :test-cmds ["clojure -M:test"]}
            {:name "rewrite-edn"
-            :version "0.4.7"
+            :version "0.4.8"
             :platforms [:clj]
             :github-release {:repo "borkdude/rewrite-edn"
                              :version-prefix "v"


### PR DESCRIPTION
Bump test and ci deps and tools to current releases.

Skipped kaocha v1.88.1376 as it seems to break clojure v1.9 compatibility. We'll wait to see if that was intentional before upgrading.

Add clj-mergetool to our lib canary tests. Closes #262.