### PR TITLE
maint: bump tools.reader

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,7 +19,7 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 === Unreleased
 
-* bump `org.clojure/tools.reader` to version `1.3.7`
+* bump `org.clojure/tools.reader` to version `1.4.2`
 * `rewrite-clj.paredit/barf-forward` on zipper created with `:track-position? true` now correctly barfs when current node has children
 https://github.com/clj-commons/rewrite-clj/issues/245[#245]
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps {org.clojure/clojure {:mvn/version "1.8.0"}
-        org.clojure/tools.reader {:mvn/version "1.3.7"}}
+        org.clojure/tools.reader {:mvn/version "1.4.2"}}
 
  :aliases {;; we use babashka/neil for project attributes
            ;; publish workflow references these values (and automatically bumps patch component of version)

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -157,7 +157,7 @@
  (patch-deps {:filename (str (fs/file home-dir "project.clj"))
               ;; we remove and add tools.reader because project.clj has pedantic? :abort enabled
               :removals #{'rewrite-clj 'org.clojure/tools.reader}
-              :additions [['org.clojure/tools.reader "1.3.7"]
+              :additions [['org.clojure/tools.reader "1.4.2"]
                           ['rewrite-clj rewrite-clj-version]]}))
 
 ;;
@@ -193,7 +193,7 @@
         (string/replace #"rewrite-clj \"(\d+\.)+.*\""
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.3.7\"")
+                        "org.clojure/tools.reader \"1.4.2\"")
         (->> (spit p)))))
 
 ;;
@@ -227,7 +227,7 @@
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         ;; pedantic is enabled for CI, so adjust to match rewrite-clj so we don't fail
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.3.7\"")
+                        "org.clojure/tools.reader \"1.4.2\"")
         (->> (spit p)))))
 
 ;;


### PR DESCRIPTION
Bump our only lib dep to current latest.

I don't see anything of concern in the diff (the current release of rewrite-clj uses 1.3.6):
https://github.com/clojure/tools.reader/compare/v1.3.6...v1.4.2

Rationales for bump:
- We want to ensure rewrite-clj works with tools.reader latest
- As part of the Clojure ecosystem, we'd like to use the latest versions of libs when possible to help validate their correctness