### PR TITLE
test & ci: bump deps

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -12,7 +12,8 @@
   rewrite-clj.zip.subedit/edit->> clojure.core/->>
   rewrite-clj.custom-zipper.switchable/defn-switchable clojure.core/defn}
  :linters
- {:redundant-fn-wrapper {:level :warning}
+ {:redundant-str-call {:level :warning}
+  :redundant-fn-wrapper {:level :warning}
   :unused-value {:level :warning}
   :aliased-namespace-symbol {:level :warning}
   :unknown-require-option {:level :off} ;; overcome a wee bug in 2020-10-05 version

--- a/deps.edn
+++ b/deps.edn
@@ -31,7 +31,7 @@
            ;;
            :lint-cache {:replace-paths ["src"]} ;; when building classpath we want to exclude resources
                                                 ;; so we do not pick up our own clj-kondo config exports
-           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.03.13"}}
+           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.22"}}
                        :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
                        :main-opts ["-m" "clj-kondo.main"]}
 
@@ -68,7 +68,7 @@
                        :extra-paths ["target/test-doc-blocks/test"]}
 
            ;; kaocha for testing clojure versions>= v1.9
-           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}
+           :kaocha {:extra-deps {lambdaisland/kaocha {:mvn/version "1.90.1383"}
                                  lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
                                  lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}}
                     :main-opts ["-m" "kaocha.runner"]}
@@ -136,7 +136,7 @@
            ;;
            ;; Deployment
            ;;
-           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.1"}}
+           :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.3"}}
                    :extra-paths ["src" "build"]
                    :ns-default build}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "karma-cljs-test": "^0.1.0",
         "karma-junit-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
-        "shadow-cljs": "^2.28.4"
+        "shadow-cljs": "^2.28.7"
       }
     },
     "node_modules/@colors/colors": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.1.tgz",
-      "integrity": "sha512-dzJtaDAAoXx4GCOJpbB2eG/Qj8VDpdwkLsWGzGm+0L7E8/434RyMbAHmk9ubXWVAb9nXmc44jUf8GKqVDiKezg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true
     },
     "node_modules/@types/cookie": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -233,12 +233,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -907,9 +907,9 @@
       "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.28.4",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.28.4.tgz",
-      "integrity": "sha512-EQQ6gMcNl+Zma+9rdOTvgd7UfbatXKAYQNKqqkWicG2neg+O7eeq2H7lcIgbxAs5Blj6bFH3k06k7iKd2ihVLA==",
+      "version": "2.28.7",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.28.7.tgz",
+      "integrity": "sha512-1faM7A9Q8LwSgYZIkKOriRb81NodwpaHCrXTbGOieo/ATLpOokzLW+IJjGYoXFdqtmWLTAtgmlRENImNvP5sQg==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "karma-cljs-test": "^0.1.0",
     "karma-junit-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
-    "shadow-cljs": "^2.28.4"
+    "shadow-cljs": "^2.28.7"
   }
 }


### PR DESCRIPTION
Of note:
- Can't resist trying a new release of clj-kondo! Enabled new linter: `:redudant-str-call`.