### PR TITLE
Support Clojure 1.12 array class tokens

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,7 +24,10 @@ A release with known breaking changes is marked with:
 * `sexpr` now 1) expands tag metadata to its long form 2) throws on invalid metadata
 https://github.com/clj-commons/rewrite-clj/issues/280[#280]
 (@lread)
-* Add support for Clojure 1.12 vector metadata
+* Add support for Clojure 1.12 vector metadata (ex. `(^[double] String/valueOf 3)` )
+https://github.com/clj-commons/rewrite-clj/issues/279[#279]
+(@lread)
+* Add support for Clojure 1.12 array class syntax (ex. `byte/3`)
 https://github.com/clj-commons/rewrite-clj/issues/279[#279]
 (@lread)
 * `rewrite-clj.paredit/barf-forward` on zipper created with `:track-position? true` now correctly barfs when current node has children

--- a/src/rewrite_clj/interop.cljc
+++ b/src/rewrite_clj/interop.cljc
@@ -39,3 +39,12 @@
   [data]
   #?(:clj (instance? clojure.lang.IMeta data)
      :cljs (implements? IWithMeta data)))
+
+(defn numeric?
+  "Checks whether a given character is numeric
+
+  Cribbed from clojure/cljs.tools.reader.impl.util."
+  [^Character ch]
+  (when ch
+    #?(:clj (Character/isDigit ch)
+       :cljs (gstring/isNumeric ch))))

--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -208,7 +208,7 @@
   "Parses a string into a vector of the namespace and symbol
 
   Cribbed from clojure/cljs.tools.reader.impl.commons/parse-symbol merging clj and cljs fns into single implementation
-  Added in equivalnt of TRDR-73 patch to allow array class symbols (e.g. foobar/3)."
+  Added in equivalent of TRDR-73 patch to allow array class symbols (e.g. foobar/3)."
   [^String token]
   (when-not (or (identical? "" token)
                 (string/ends-with? token ":")

--- a/test/rewrite_clj/node/coercer_test.cljc
+++ b/test/rewrite_clj/node/coercer_test.cljc
@@ -23,6 +23,7 @@
 
              ;; symbol/keyword/string/...
              ['symbol                :token      :symbol]
+             [(symbol "ns" "3")      :token      :symbol]
              ['namespace/symbol      :token      :symbol]
              [:keyword               :token      :keyword]
              [:1.5.1                 :token      :keyword]

--- a/test/rewrite_clj/node_test.cljc
+++ b/test/rewrite_clj/node_test.cljc
@@ -24,6 +24,7 @@
              ["[1 2 3]"         :vector         :seq                true]
              ["\"string\""      :token          :string             true]
              ["symbol"          :token          :symbol             true]
+             ["foo/3"           :token          :symbol             true]
              ["43"              :token          :token              true]
              ["#_ nope"         :uneval         :uneval             false]
              ["  "              :whitespace     :whitespace         false]]]
@@ -201,3 +202,21 @@
       (is (= 'my.current.ns (custom-mqn-sexpr "#:: {:a 1 :b 2}")))
       (is (= 'my.aliased.ns (custom-mqn-sexpr "#::my-alias {:a 1 :b 2}")))
       (is (= 'my-alias-nope-unresolved (custom-mqn-sexpr "#::my-alias-nope {:a 1 :b 2}"))))))
+
+(deftest t-create-nodes
+  ;; The *-node creation fns were initially created to serve the parser, and are therefore not
+  ;; always entirely user-friendly, but are often useful.
+  ;; Here's a good place to add some tests as we see fit.
+  (doseq
+   [[n expected-node-type expected-str expected-sexpr]
+    [[(n/token-node (symbol "foobar" "3")) :symbol "foobar/3"        (symbol "foobar" "3")]
+     [(n/token-node (symbol "sym"))        :symbol "sym"             'sym]
+     [(n/token-node '\newline "\\newline") :token  "\\newline"       '\newline]
+     [(n/token-node 42)                    :token  "42"              42]
+     [(n/token-node +42 "+42")             :token  "+42"             42]
+     [(n/token-node "foo")                 :token  "\"foo\""         "foo"]]]
+
+    (testing expected-str
+      (is (= expected-node-type (proto/node-type n)))
+      (is (= expected-str (n/string n)))
+      (is (= expected-sexpr (n/sexpr n))))))

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -52,6 +52,7 @@
            ["\\\\"                       \\]
            ["\\a"                        \a]
            ["\\space"                    \space]
+           ["\\u2202"                    \u2202]
            ["\\'"                        \']
            [":1.5"                       :1.5]
            [":1.5.0"                     :1.5.0]
@@ -68,6 +69,15 @@
       (is (= :token (node/tag n)))
       (is (= s (node/string n)))
       (is (= r (node/sexpr n))))))
+
+(deftest t-parsing-clojure-1-12-array-class-tokens
+  (doseq [dimension (range 1 10)]
+    (let [s (str "foobar/" dimension)
+          n (p/parse-string s)]
+      (is (= :token (node/tag n)))
+      (is (= s (node/string n)))
+      (is (= (symbol "foobar" (str dimension))
+             (node/sexpr n))))))
 
 (deftest t-parsing-garden-selectors
   ;; https://github.com/noprompt/garden
@@ -564,6 +574,8 @@
            ["\"abc"                 #".*EOF.*"]
            ["#\"abc"                #".*Unexpected EOF.*"]
            ["(def x 0]"             #".*Unmatched delimiter.*"]
+           ["foobar/0"              #".*Invalid symbol: foobar/0"]  ;; array class dimension can be 1 to 9
+           ["foobar/11"             #".*Invalid symbol: foobar/11"] ;; array class dimension can be 1 to 9
            ["##wtf"                 #".*Invalid token: ##wtf"]
            ["#="                    #".*:eval node expects 1 value.*"]
            ["#^"                    #".*:meta node expects 2 values.*"]
@@ -581,7 +593,7 @@
            ["#:: token"             #".*namespaced map expects a map*"]
            ["#::alias [a]"          #".*namespaced map expects a map*"]
            ["#:prefix [a]"          #".*namespaced map expects a map.*"]]]
-       (is (thrown-with-msg? ExceptionInfo p (p/parse-string s)))))
+       (is (thrown-with-msg? ExceptionInfo p (p/parse-string s)) s)))
 
 (deftest t-sexpr-exceptions
   (doseq [s ["#_42"                 ;; reader ignore/discard


### PR DESCRIPTION
The new `foo/3` was reader-illegal prior to 1.12.

Bring in and customize some tools.reader bits and bobs to support reading this new syntax.

Clojure's `symbol` allows us to construct technically illegal symbols, we take advantage of this to test and support this new syntax in any version of Clojure via, for example, `(symbol "foo" "3")`.

Closes #279