### PR TITLE
docs: changelog: link to issue and contributors

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,11 @@
 = Changelog
 :toc:
 :toclevels: 1
+:issue: https://github.com/clj-commons/rewrite-clj/issues/
+:pr: https://github.com/clj-commons/rewrite-clj/pull/
+:person: https://github.com/
+:lread: {person}lread[@lread]
+:borkdude: {person}borkdude[@borkdude]
 
 [.normal]
 A release with known breaking changes is marked with:
@@ -20,25 +25,20 @@ A release with known breaking changes is marked with:
 === Unreleased
 
 * bump `org.clojure/tools.reader` to version `1.4.2`
-(@lread)
+({lread})
 * `sexpr` now 1) expands tag metadata to its long form 2) throws on invalid metadata
-https://github.com/clj-commons/rewrite-clj/issues/280[#280]
-(@lread)
+{issue}280[#280] ({lread})
 * Add support for Clojure 1.12 vector metadata (ex. `(^[double] String/valueOf 3)` )
-https://github.com/clj-commons/rewrite-clj/issues/279[#279]
-(@lread)
+{issue}279[#279] ({lread})
 * Add support for Clojure 1.12 array class syntax (ex. `byte/3`)
-https://github.com/clj-commons/rewrite-clj/issues/279[#279]
-(@lread)
+{issue}279[#279] ({lread})
 * `rewrite-clj.paredit/barf-forward` on zipper created with `:track-position? true` now correctly barfs when current node has children
-https://github.com/clj-commons/rewrite-clj/issues/245[#245]
-(@lread, thanks for the issue @p4ulcristian!)
+{issue}245[#245] ({lread}, thanks for the issue {person}p4ulcristian[@p4ulcristian]!)
 
 === v1.1.47 - 2023-03-25 [[v1.1.47]]
 
 * Clojure string to rewrite-clj node coercion fixes
-https://github.com/clj-commons/rewrite-clj/issues/214[#214]
-(@borkdude/@lread collab)
+{issue}214[#214] ({borkdude} & {lread} collab)
 ** `"a\n\b\r\nc"` is now preserved as is.
 It was being coerced to:
 +
@@ -57,99 +57,127 @@ https://github.com/clj-commons/rewrite-clj/compare/v1.1.46\...v1.1.47[commit log
 === v1.1.46 - 2023-01-30 [[v.1.1.46]]
 
 * added new `rewrite-clj.zip` functions `of-string*` and `of-file*`, these are versions of `of-string` and `of-file` that do no auto-navigation
-https://github.com/clj-commons/rewrite-clj/issues/189[#189]
-(thanks @mainej for the analysis work)
-* a lazy sequence now coerces to a rewrite-clj list node https://github.com/clj-commons/rewrite-clj/pull/180[#180] (thanks @borkdude!)
-* exceptions thrown while reading now include `:row` and `:col` keys in `ex-data` https://github.com/clj-commons/rewrite-clj/pull/181[#181] (thanks @ferdinand-beyer)
+{issue}189[#189] ({lread}, thanks {person}mainej[@mainej] for the analysis work!)
+* a lazy sequence now coerces to a rewrite-clj list node
+{pr}180[#180] (thanks {borkdude}!)
+* exceptions thrown while reading now include `:row` and `:col` keys in `ex-data`
+{pr}181[#181] (thanks {person}ferdinand-beyer[@ferdinand-beyer])
 * docs
-** a docstring typo fix https://github.com/clj-commons/rewrite-clj/pull/191[#191] (thanks @BTowersCoding!)
-* Implement equality for seq nodes https://github.com/clj-commons/rewrite-clj/issues/212[#212] (@borkdude)
+** a docstring typo fix
+{pr}191[#191] (thanks {person}bobbicodes[@bobbicodes]!)
+* Implement equality for seq nodes
+{issue}212[#212] ({borkdude})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.1.45\...v1.1.46[commit log]
 
 === v1.1.45 - 2022-06-09 [[v1.1.45]]
 
 * dropped the alpha status
-* changed rewrite-clj library version scheme from commit-count to release-num https://github.com/clj-commons/rewrite-clj/issues/179[#179]
+({lread})
+* changed rewrite-clj library version scheme from commit-count to release-num
+{issue}179[#179] ({lread})
 * renamed zipper creation functions that take a rewrite-clj node as input.
 The old names did not reflect their purpose which led to confusion.
-Old functions will remain but are marked as deprecated. https://github.com/clj-commons/rewrite-clj/issues/178[#178]
+Old functions will remain but are marked as deprecated.
+{issue}178[#178] ({lread})
 ** `rewrite-clj.zip/edn` -> `rewrite-clj.zip/of-node`
 ** `rewrite-clj.zip/edn*` -> `rewrite-clj.zip/of-node*`
-* now properly escaping inline double quotes for coerced strings https://github.com/clj-commons/rewrite-clj/issues/176[#176] - thanks to @ivarref for raising the issue!
+* now properly escaping inline double quotes for coerced strings
+{issue}176[#176] ({lread}, thanks to {person}ivarref[@ivarref] for raising the issue!
 * docs:
-** docstring fix, was missing `list-node` from toc, thanks @rfhayashi!
+** docstring fix, was missing `list-node` from toc
+(thanks {person}rfhayashi[@rfhayashi]!)
 
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.767-alpha\...v1.1.45[commit log]
 
 === v1.0.767-alpha - 2022-04-05 [[v1.0.767-alpha]]
 
-* fix `:end-row` `:end-col` metadata for root node https://github.com/clj-commons/rewrite-clj/issues/173[#173] - thanks @mainej!
+* fix `:end-row` `:end-col` metadata for root node
+{issue}173[#173] (thanks {person}mainej[@mainej]!)
 * docs:
-** user guide correction, thanks @rgkirch!
-** zip API docstrings now clearer about coercion https://github.com/clj-commons/rewrite-clj/issues/168[#168]
+** user guide correction
+(thanks {person}rgkirch[@rgkirch]!)
+** zip API docstrings now clearer about coercion
+{issue}168[#168] ({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.699-alpha\...v1.0.767-alpha[commit log]
 
 === v1.0.699-alpha - 2021-10-10 [[v1.0.699-alpha]]
 
-* team update: @borkdude is now officially a co-maintainer of rewrite-clj! Woot woot!
-* rewrite-clj v1 minimum Clojure version is now v1.8.0 (was formerly v1.9.0) https://github.com/clj-commons/rewrite-clj/issues/164[#164]
+* team update: {borkdude} is now officially a co-maintainer of rewrite-clj! Woot woot!
+* rewrite-clj v1 minimum Clojure version is now v1.8.0 (was formerly v1.9.0)
+{issue}164[#164] ({lread})
 * internal rewrite-clj developer facing:
 ** Migrate from `depstar` to `tools.build`
+({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.682-alpha\...v1.0.699-alpha[commit log]
 
 === v1.0.682-alpha - 2021-08-23 [[v1.0.682-alpha]]
 
 * update clojure tools.reader dependency to v1.3.6
-* a zipper created with both a custom `:auto-resolve` option and the `:track-position?` `true` option will now acknowledge and use the custom `:auto-resolve` https://github.com/clj-commons/rewrite-clj/issues/159[#159]
-* a Cons now coerces to a rewrite-clj list node https://github.com/clj-commons/rewrite-clj/issues/160[#160] https://github.com/clj-commons/rewrite-clj/issues/161[#161] (thanks @borkdude!)
+({lread})
+* a zipper created with both a custom `:auto-resolve` option and the `:track-position?` `true` option will now acknowledge and use the custom `:auto-resolve`
+{issue}159[#159] ({lread})
+* a Cons now coerces to a rewrite-clj list node
+{issue}160[#160] {issue}/161[#161] (thanks {borkdude}!)
 * internal rewrite-clj developer facing:
-** Now also linting rewrite-clj sources with Eastwood https://github.com/clj-commons/rewrite-clj/pull/158[#158] (thanks @vemv!)
+** Now also linting rewrite-clj sources with Eastwood
+{pr}158[#158] (thanks {person}vemv[@vemv]!)
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.644-alpha\...v1.0.682-alpha[commit log]
 
 === v1.0.644-alpha - 2021-05-27 [[v1.0.644-alpha]]
 
-* user guide and docstrings better explain `sexpr-able?` and what invalid code elements rewrite-clj parses https://github.com/clj-commons/rewrite-clj/issues/150[#150] https://github.com/clj-commons/rewrite-clj/issues/151[#151]
-* rewrite-clj now exports clj-kondo config for its public API https://github.com/clj-commons/rewrite-clj/issues/146[#146]
-* ClojureScript compiler should no longer emit invalid deprecated warnings https://github.com/clj-commons/rewrite-clj/issues/153[#153]
+* user guide and docstrings better explain `sexpr-able?` and what invalid code elements rewrite-clj parses
+{issue}150[#150] {issue}/151[#151] ({lread})
+* rewrite-clj now exports clj-kondo config for its public API
+{issue}146[#146] ({lread})
+* ClojureScript compiler should no longer emit invalid deprecated warnings
+{issue}153[#153] ({lread})
 * Internal rewrite-clj developer facing:
 ** Switched from babashka scripts to babashka tasks, developer guide updated accordingly
+({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.605-alpha\...v1.0.644-alpha[commit log]
 
 === v1.0.605-alpha -  2021-04-02 [[v1.0.605-alpha]]
 
-* rewrite-clj now understands the `#!` comment, a construct often used in scripts https://github.com/clj-commons/rewrite-clj/issues/145[#145]
+* rewrite-clj now understands the `#!` comment, a construct often used in scripts
+{issue}145[#145] ({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.594-alpha\...v1.0.605-alpha[commit log]
 
 === v1.0.594-alpha - 2021-03-20 [[v1.0.594-alpha]]
 
-* rewrite-clj now explicitly depends on the minimum version of Clojure required, v1.9.0, rather than v1.10.3 https://github.com/clj-commons/rewrite-clj/issues/142[#142]
+* rewrite-clj now explicitly depends on the minimum version of Clojure required, v1.9.0, rather than v1.10.3
+{issue}142[#142] ({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.591-alpha\...v1.0.594-alpha[commit log]
 
 === v1.0.591-alpha - 2021-03-16 [[v1.0.591-alpha]]
 
-* namespaced map should allow all Clojure whitespace between prefix and map https://github.com/clj-commons/rewrite-clj/issues/140[#140]
-* Beef up docs on node creation https://github.com/clj-commons/rewrite-clj/issues/97[#97]
-* Describe subedit in docs https://github.com/clj-commons/rewrite-clj/issues/111[#111]
+* namespaced map should allow all Clojure whitespace between prefix and map
+{issue}140[#140] ({lread})
+* Beef up docs on node creation
+{issue}97[#97] ({lread})
+* Describe subedit in docs
+{issue}111[#111] ({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.579-alpha\...v1.0.591-alpha[commit log]
 
 === v1.0.579-alpha - 2021-03-11 [[v1.0.579-alpha]]
 
 * Release workflow now creates a GitHub release
+({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.574-alpha\...v1.0.579-alpha[commit log]
 
 === v1.0.574-alpha - 2021-03-10 [[v1.0.579-alpha]]
 
-* Docs now render on cljdoc https://github.com/clj-commons/rewrite-clj/issues/138[#138]
+* Docs now render on cljdoc
+{issue}138[#138] ({lread})
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.0.572-alpha\...v1.0.574-alpha[commit log]
 
@@ -338,8 +366,10 @@ a| ns-alias qualified
 * Potentially breaking
 ** Some http://rundis.github.io/blog/2015/clojurescript_performance_tuning.html[rewrite-cljs optimizations] were dropped in favor of a single code base.
 If performance for rewrite-clj v1 for ClojureScript users is poor with today's ClojureScript, we shall adapt.
-** Deleted unused `rewrite-clj.node.indent` https://github.com/clj-commons/rewrite-clj/issues/116[#116]
-** Deleted redundant `rewrite-clj.parser.util` as part of https://github.com/clj-commons/rewrite-clj/issues/93[#93].
+** Deleted unused `rewrite-clj.node.indent`
+{issue}116[#116] ({lread})
+** Deleted redundant `rewrite-clj.parser.util`
+{issue}93[#93] ({lread}).
 If you were using this internal namespace you can opt to switch to, the also internal, `rewrite-clj.reader` namespace.
 
 ==== Other Changes
@@ -382,40 +412,64 @@ Rewrite-cljs users migrating to rewrite-clj v1 are now at, and will remain at, f
 * Many updates to docs and docstrings
 
 ==== Fixes
-* OS specific end of line variants in source now normalized consistently to `\newline` https://github.com/clj-commons/rewrite-clj/issues/93[#93]
-* Postwalk on larger source file no longer throws StackOverflow https://github.com/clj-commons/rewrite-clj/issues/69[#69]
-* Postwalk now walks in post order https://github.com/clj-commons/rewrite-clj/issues/123[#123]
-* We now preserve newline at end of file https://github.com/clj-commons/rewrite-clj/issues/121[#121]
-* Support for garden style selectors https://github.com/clj-commons/rewrite-clj/issues/92[#92]
-* Correct and document prefix and suffix functions https://github.com/clj-commons/rewrite-clj/issues/91[#91]
-* Positional metadata added by the reader is elided on coercion https://github.com/clj-commons/rewrite-clj/issues/90[#90]
-* Can now read `\\##Inf`, `##-Inf` and `##Nan` https://github.com/clj-commons/rewrite-clj/issues/75[#75]
+* OS specific end of line variants in source now normalized consistently to `\newline`
+{issue}93[#93] ({lread})
+* Postwalk on larger source file no longer throws StackOverflow
+{issue}69[#69] ({lread})
+* Postwalk now walks in post order
+{issue}123[#123] ({lread})
+* We now preserve newline at end of file
+{issue}121[#121] ({lread})
+* Support for garden style selectors
+{issue}92[#92] ({lread})
+* Correct and document prefix and suffix functions
+{issue}91[#91] ({lread})
+* Positional metadata added by the reader is elided on coercion
+{issue}90[#90] ({lread})
+* Can now read `\\##Inf`, `##-Inf` and `##Nan`
+{issue}75[#75] ({lread})
 * Ensure that all rewrite-clj nodes coerce to themselves
-* Strings now coerce to string nodes (instead of to token nodes) https://github.com/clj-commons/rewrite-clj/issues/126[#126]
-* Regexes now coerce to regex nodes https://github.com/clj-commons/rewrite-clj/issues/128[#128]
+({lread})
+* Strings now coerce to string nodes (instead of to token nodes)
+{issue}126[#126] ({lread})
+* Regexes now coerce to regex nodes
+{issue}128[#128] ({lread})
 * Regex node now:
-** converts correctly to string https://github.com/clj-commons/rewrite-clj/issues/127[#127]
-** reports correct length https://github.com/clj-commons/rewrite-clj/issues/130[#130]
-* Moved from potemkin import-vars to static template based version https://github.com/clj-commons/rewrite-clj/issues/98[#98]:
+** converts correctly to string
+{issue}127[#127] ({lread})
+** reports correct length
+{issue}130[#130] ({lread})
+* Moved from potemkin import-vars to static template based version
+{issue}98[#98] ({lread}):
 ** Avoids frustration/mysteries of dynamic import-vars for users and maintainers
 ** Argument names now correct in API docs (some were gensymed previously)
 ** Also turfed use of custom version of potemkin defprotocol+ in favor of plain old defprotocol.
 Perhaps I missed something, but I did not see the benefit of defprotocol+ for rewrite-clj v1.
 
 ==== Internal changes (developer facing)
-* Tests updated to hit public APIs https://github.com/clj-commons/rewrite-clj/issues/106[#106]
+* Tests updated to hit public APIs
+{issue}106[#106] ({lread})
 * ClojureScript tests, in addition to being run under node, are now also run under chrome-headless, shadow-cljs, and for self-hosted ClojureScript, under planck.
-* Now testing rewrite-clj compiled under GraalVM native-image in two variants:
+({lread})
+* Now testing rewrite-clj compiled under GraalVM native-image in two variants ({lread}):
 ** In a pure form where library and tests are compiled
 ** Via sci where a sci exposed rewrite-clj is compiled, then tests are interpreted.
-* Now automatically testing rewrite-clj against popular libs https://github.com/clj-commons/rewrite-clj/issues/124[#124]
+* Now automatically testing rewrite-clj against popular libs
+{issue}124[#124] ({lread})
 * Now linting source with clj-kondo
+({lread})
 * Code coverage reports now generated for Clojure unit test run and sent to codecov.io
+({lread})
 * Can now preview for cljdoc locally via `script/cljdoc_preview.clj`
+({lread})
 * API diffs for rewrite-clj v1 vs rewrite-clj v0 vs rewrite-cljs can be generated by `script/gen_api_diffs.clj`
+({lread})
 * Contributors are acknowledged in README and updated via `script/update_readme.clj`
-* Doc code blocks are automatically tested via `script/doc_tests.clj` https://github.com/clj-commons/rewrite-clj/issues/100[#100]
-* Some tooling and tech replaced:
+({lread})
+* Doc code blocks are automatically tested via `script/doc_tests.clj`
+{issue}100[#100] ({lread})
+* Some tooling and tech replaced
+({lread}):
 ** All scripts are written in Clojure and run via Babashka or Clojure.
 ** Switched from leiningen `project.clj` to Clojure tools CLI `deps.edn`
 ** Moved from CommonMark to AsciiDoc for docs
@@ -425,45 +479,52 @@ Perhaps I missed something, but I did not see the benefit of defprotocol+ for re
 ** Adopted kaocha for Clojure testing, stuck with doo for regular ClojureScript testing, and added support for ClojureScript watch testing with figwheel main.
 ** Potemkin dynamic import-vars replaced with static code generation solution
 * Added GitHub issue templates
-* Fixed a generative test sporadic failure https://github.com/clj-commons/rewrite-clj/issues/88[#88]
+({lread})
+* Fixed a generative test sporadic failure
+{issue}88[#88] ({lread})
 
 == rewrite-clj v0
 
 === 0.6.0 [breaking] - 2016-10-02
 
-* **BREAKING**: uses a dedicated node type for regular expressions. (see #49 –
-  thanks @ChrisBlom!)
-* implement `NodeCoercable` for `nil`. (set #53 – thanks @jespera!)
+* **BREAKING**: uses a dedicated node type for regular expressions.
+{issue}49[#49] (thanks {person}ChrisBlom[@ChrisBlom])
+* implement `NodeCoercable` for `nil`.
+{issue}53[#53] (thanks {person}jespera[@jespera]!)
 
 === 0.5.2 - 2016-08-31
 
-* fixes parsing of splicing reader conditionals `#?@...`. (see #48)
+* fixes parsing of splicing reader conditionals `#?@...`.
+{pr}48[#48] (thanks {person}arrdem[@arrdem]!)
 
 === 0.5.1 - 2016-07-08
 
-* fixes parsing of multi-line regular expressions. (see #51)
+* fixes parsing of multi-line regular expressions.
+{pr}51[#51] (thanks {person}brian-dawn[@brian-dawn]!)
 
 === 0.5.0 [breaking] - 2016-04-03
 
-* **BREAKING**: commas will no longer be parsed into `:whitespace` nodes but
-  `:comma`. (see #44 - thanks @arrdem!)
-* **BREAKING**: `position` will throw exception if not used on rewrite-clj
-  custom zipper. (see #45)
+* **BREAKING**: commas will no longer be parsed into `:whitespace` nodes but `:comma`.
+{pr}44[#44] (thanks {person}arrdem[@arrdem]!)
+* **BREAKING**: `position` will throw exception if not used on rewrite-clj custom zipper.
+{pr}45[#45] ({person}xsc[@xsc])
 * **BREAKING**: drops testing against JDK6.
 * **DEPRECATED**:
 ** `append-space` in favour of `insert-space-right`
 ** `prepend-space` in favour of `insert-space-left`
 ** `append-newline` in favour of `insert-newline-right`
 ** `prepend-newline` in favour of `insert-newline-left`
-* fix insertion of nodes in the presence of existing whitespace. (see #33, #34 -
-  thanks @eraserhd!)
-* `edn` and `edn*` now take a `:track-position?` option that activates a custom
-  zipper implementation allowing `position` to be called on. (see #41, #45 -
-  thanks @eraserhd!)
-* fix parsing of whitespace, e.g. `<U+2028>`. (see #43)
-* fix serialization of `integer-node`s. (see #37 - thanks @eraserhd!)
+* fix insertion of nodes in the presence of existing whitespace.
+{pr}33[#33], {pr}34[34] (thanks {person}eraserhd[@eraserhd]!)
+* `edn` and `edn*` now take a `:track-position?` option that activates a custom zipper implementation allowing `position` to be called on.
+{pr}41[#41], {pr}45[45] (thanks {person}eraserhd[@eraserhd]!)
+* fix parsing of whitespace, e.g. `<U+2028>`.
+{issue}43[#43] ({person}xsc[@xsc])
+* fix serialization of `integer-node`s.
+{pr}37[#37] (thanks {person}eraserhd[@eraserhd]!)
 * adds `insert-left*` and `insert-right*` to facade.
-* generative tests. (see #41 - thanks @eraserhd!)
+* generative tests.
+{pr}41[#41] (thanks {person}eraserhd[@eraserhd]!)
 
 === 0.4.13 - 2016-04-02
 
@@ -478,36 +539,45 @@ _Development has branched off, using the `0.4.x` branch_
 
 === 0.4.12 - 2015-02-15
 
-* drop `fast-zip` and `potemkin` dependencies. (see #26)
+* drop `fast-zip` and `potemkin` dependencies.
+{issue}26[#26] ({person}xsc[@xsc])
 
 === 0.4.11 - 2015-02-05
 
-* fix handling of symbols with boundary character inside. (see #25)
+* fix handling of symbols with boundary character inside.
+{issue}25[#25] ({person}xsc[@xsc])
 
 === 0.4.10 - 2015-02-04
 
-* fix handling of symbols with trailing quote, e.g. `x'`. (see #24)
+* fix handling of symbols with trailing quote, e.g. `x'`.
+{issue}24[#24] ({person}xsc[@xsc])
 
 === 0.4.9 - 2015-01-31
 
-* fix `replace-children` for `:uneval` nodes. (see #23)
-* add `rewrite-clj.zip/postwalk`. (see #22)
+* fix `replace-children` for `:uneval` nodes.
+{issue}23[#23] ({person}xsc[@xsc])
+* add `rewrite-clj.zip/postwalk`.
+{issue}22[#22] ({person}xsc[@xsc])
 
 === 0.4.8 - 2015-01-29
 
-* allow parsing of aliased keywords, e.g. `::ns/foo`. (see #21)
+* allow parsing of aliased keywords, e.g. `::ns/foo`.
+{issue}21[#21] ({person}xsc[@xsc])
 
 === 0.4.7 - 2015-01-28
 
-* fixes zipper creation over whitespace-/comment-only data. (see #20)
+* fixes zipper creation over whitespace-/comment-only data.
+{issue}20[#20] ({person}xsc[@xsc])
 
 === 0.4.6 - 2015-01-28
 
-* fixes parsing of empty comments. (see #19)
+* fixes parsing of empty comments.
+{issue}19[#19] ({person}xsc[@xsc])
 
 === 0.4.5 - 2015-01-25
 
-* fixes parsing of comments that are at the end of a file without linebreak. (see #18)
+* fixes parsing of comments that are at the end of a file without linebreak.
+{issue}18[#18] ({person}xsc[@xsc])
 
 === 0.4.4 - 2015-01-18
 
@@ -516,7 +586,8 @@ _Development has branched off, using the `0.4.x` branch_
 
 === 0.4.3 - 2015-01-18
 
-* fix parsing of backslash `\\` character. (see #17)
+* fix parsing of backslash `\\` character.
+{issue}17[#17] ({person}xsc[@xsc])
 
 === 0.4.2 - 2015-01-16
 
@@ -533,14 +604,17 @@ _Development has branched off, using the `0.4.x` branch_
 * **BREAKING** node creation/edit has stricter preconditions (e.g. `:meta` has to
   contain exactly two non-whitespace forms).
 * **BREAKING** moved to a type/protocol based implementation of nodes.
-* fix radix support. (see #13)
-* fix handling of spaces between certain forms. (see #7)
+* fix radix support.
+{issue}13[#13] ({person}xsc[@xsc])
+* fix handling of spaces between certain forms.
+{issue}7[#7] ({person}xsc[@xsc])
 * add node constructor functions.
 * add `child-sexprs` function.
 
 === 0.3.12 - 2014-12-14
 
-* fix `assoc` on empty map. (see #16)
+* fix `assoc` on empty map.
+{issue}16[#16] ({person}xsc[@xsc])
 
 === 0.3.11 - 2014-10-23
 
@@ -557,8 +631,10 @@ _Development has branched off, using the `0.4.x` branch_
 === 0.3.9 - 2014-03-29
 
 * add `end?`.
-* allow access to children of quoted forms. (see #6)
-* fix children lookup for zipper (return `nil` on missing children). (see #5)
+* allow access to children of quoted forms.
+{issue}6[#6] ({person}xsc[@xsc])
+* fix children lookup for zipper (return `nil` on missing children).
+{issue}5[#5] ({person}xsc[@xsc])
 
 === 0.3.8 - 2014-03-15
 


### PR DESCRIPTION
Was not linking to contributors.
Was not always linking to issue/pr.
Use adoc attributes to make this a little less error prone and easy to maintain.

[skip ci]