### PR TITLE
test & ci: bump deps

### DIFF
--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, ubuntu, macos ]
-        java-version: [ '22.0.1' ]
+        java-version: [ '22.0.2' ]
         test: [ native, native-sci ]
         clojure-version: [ '1.11', '1.12' ]
 

--- a/deps.edn
+++ b/deps.edn
@@ -160,7 +160,7 @@
            ;;
            ;; Maintenance support
            ;;
-           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.8.1201"}
+           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.8.1206"}
                                    org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
                                    }
                       :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}


### PR DESCRIPTION
Of note: new patch release of GraalVM (used for native image tests)