### PR TITLE
dev: bump da kondo

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -52,7 +52,7 @@
            ;;
            :lint-cache {:replace-paths ["src"]} ;; when building classpath we want to exclude resources
                                                 ;; so we do not pick up our own clj-kondo config exports
-           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
+           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.01"}}
                        :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
                        :main-opts ["-m" "clj-kondo.main"]}
 

--- a/script/lint_kondo.clj
+++ b/script/lint_kondo.clj
@@ -25,11 +25,8 @@
                    with-out-str
                    string/trim)
         bb-cp (bbcp/get-classpath)]
-
-    (status/line :detail "- copying configs")
-    (shell/command "clojure -M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
-    (status/line :detail "- creating cache")
-    (shell/command "clojure -M:clj-kondo --dependencies --parallel --lint" clj-cp bb-cp)))
+    (status/line :detail "- copying lib configs and creating cache")
+    (shell/command "clojure -M:clj-kondo --skip-lint --copy-configs --dependencies --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild-cache]}]
   (status/line :head "clj-kondo: cache check")
@@ -53,7 +50,7 @@
   (status/line :head "clj-kondo: linting")
   (let [{:keys [exit]}
         (shell/command {:continue true}
-                       "clojure -M:clj-kondo --lint src test script deps.edn build.clj")]
+                       "clojure -M:clj-kondo --parallel --lint src test script deps.edn build.clj")]
     (cond
       (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")


### PR DESCRIPTION
Also, take advantage of clj-kondo's new ability to copy configs and create cache at same time.