### PR TITLE
maint: bump tools.reader

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,9 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 === Unreleased
 
+* bump `org.clojure/tools.reader` to version `1.5.0`
+({lread})
+
 === v1.1.48 - 2024-08-15 [[v1.1.48]]
 
 * bump `org.clojure/tools.reader` to version `1.4.2`

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps {org.clojure/clojure {:mvn/version "1.8.0"}
-        org.clojure/tools.reader {:mvn/version "1.4.2"}}
+        org.clojure/tools.reader {:mvn/version "1.5.0"}}
 
  :aliases {;; we use babashka/neil for project attributes
            ;; publish workflow references these values (and automatically bumps patch component of version)

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -157,7 +157,7 @@
  (patch-deps {:filename (str (fs/file home-dir "project.clj"))
               ;; we remove and add tools.reader because project.clj has pedantic? :abort enabled
               :removals #{'rewrite-clj 'org.clojure/tools.reader}
-              :additions [['org.clojure/tools.reader "1.4.2"]
+              :additions [['org.clojure/tools.reader "1.5.0"]
                           ['rewrite-clj rewrite-clj-version]]}))
 
 ;;
@@ -193,7 +193,7 @@
         (string/replace #"rewrite-clj \"(\d+\.)+.*\""
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.4.2\"")
+                        "org.clojure/tools.reader \"1.5.0\"")
         (->> (spit p)))))
 
 ;;
@@ -227,7 +227,7 @@
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         ;; pedantic is enabled for CI, so adjust to match rewrite-clj so we don't fail
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.4.2\"")
+                        "org.clojure/tools.reader \"1.5.0\"")
         (->> (spit p)))))
 
 ;;


### PR DESCRIPTION
Bump rewrite-clj tools.reader dep to 1.5.0, the current latest. Rewrite-clj does not rely on its new 1.12 syntax support, we added support in before 1.5.0 was released, but:
- We want to ensure rewrite-clj works with tools.reader latest
- As part of the Clojure ecosystem, we'd like to use the latest versions of libs when possible to help validate their correctness