### PR TITLE
dev & ci: more clojure 1.12

### DIFF
--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ windows, ubuntu, macos ]
         java-version: [ '22.0.2' ]
         test: [ native, native-sci ]
-        clojure-version: [ '1.11', '1.12' ]
+        clojure-version: [ '1.12' ]
 
     name: ${{ matrix.os }},jdk${{ matrix.java-version }},${{ matrix.test }},clj${{ matrix.clojure-version }}
 

--- a/deps.edn
+++ b/deps.edn
@@ -51,7 +51,7 @@
            :lint-cache {:replace-paths ["src"]} ;; when building classpath we want to exclude resources
                                                 ;; so we do not pick up our own clj-kondo config exports
            :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.29"}}
-                       :override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+                       :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                        :main-opts ["-m" "clj-kondo.main"]}
 
            :eastwood {:extra-deps {jonase/eastwood {:mvn/version "1.4.3"}}
@@ -74,7 +74,7 @@
            :test-isolated {:extra-paths ["test-isolated"]}
 
            ;; document block testing
-           :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.11.4"}
+           :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
                                             com.github.lread/test-doc-blocks  {:mvn/version "1.1.20"}}
                              :replace-paths []
                              :ns-default lread.test-doc-blocks
@@ -83,7 +83,7 @@
                                                 "doc/design/namespaced-elements.adoc"
                                                 "src/rewrite_clj/node.cljc"]}}
 
-           :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+           :test-docs {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                        :extra-paths ["target/test-doc-blocks/test"]}
 
            ;; kaocha for testing clojure versions>= v1.9
@@ -100,7 +100,7 @@
 
            ;; figwheel for clojurescript testing during dev
            :fig-test {:extra-deps {com.bhauman/figwheel-main {:mvn/version "0.2.18"}}
-                      :override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+                      :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                       :extra-paths ["target" "test"]
                       :main-opts ["-m" "figwheel.main" "-b" "fig" "-r"]}
 
@@ -115,11 +115,11 @@
            ;; General script deps
            ;;
            :script {:extra-paths ["script"]
-                    :override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+                    :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                     :extra-deps {org.clojure/tools.namespace {:mvn/version "1.5.0"}
                                  cli-matic/cli-matic {:mvn/version "0.5.4"}}}
 
-           :apply-import-vars {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+           :apply-import-vars {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                                :extra-deps {metosin/malli {:mvn/version "0.16.4"}
                                             io.aviso/pretty {:mvn/version "1.4.4"}}
                                :ns-default lread.apply-import-vars}
@@ -131,7 +131,7 @@
            ;; graal:sci-test - interpret tests via sci over natively compiled rewrite-clj
            ;; graal:native-test - natively compile src and tests and run
 
-           :graal {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}
+           :graal {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                    :extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "1.0.5"}}}
 
 
@@ -161,7 +161,7 @@
            :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.9.1221"}
                                    org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
                                    }
-                      :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+                      :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                       :main-opts ["-m" "antq.core"
                                   "--ignore-locals"
                                   "--exclude=lambdaisland/kaocha@1.88.1376" ;; breaks clojure 1.9 compat, let's wait to see if that was intentional

--- a/script/dev_repl.clj
+++ b/script/dev_repl.clj
@@ -44,7 +44,7 @@
     (if (:help opts)
       (usage-help)
       (do (status/line :head "Launching Clojure %s nREPL" (name flavor))
-          (process/exec "clj" (str "-M:1.11:test-common:nrepl:nrepl/" (case flavor
+          (process/exec "clj" (str "-M:1.12:test-common:nrepl:nrepl/" (case flavor
                                                                         :cljs "cljs:cljs"
                                                                         :jvm  "jvm"))
                         "-h" (:host opts)

--- a/script/test_jvm_sci.clj
+++ b/script/test_jvm_sci.clj
@@ -5,12 +5,12 @@
             [helper.shell :as shell]
             [lread.status-line :as status]))
 
-(def allowed-clojure-versions '("1.10" "1.11"))
+(def allowed-clojure-versions '("1.11" "1.12"))
 
 (def args-usage "Valid args: [options]
 
 Options:
-  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11] [default: 1.11]
+  -v, --clojure-version VERSION  Test with Clojure [1.11, 1.12] [default: 1.12]
   --help                         Show this help")
 
 

--- a/script/test_native.clj
+++ b/script/test_native.clj
@@ -22,7 +22,7 @@
 (def args-usage "Valid args: [options]
 
 Options:
-  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11, 1.12] [default: 1.11]
+  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11, 1.12] [default: 1.12]
   --help                         Show this help")
 
 

--- a/script/test_native_sci.clj
+++ b/script/test_native_sci.clj
@@ -29,7 +29,7 @@
 (def args-usage "Valid args: [options]
 
 Options:
-  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11, 1.12] [default: 1.11]
+  -v, --clojure-version VERSION  Test with Clojure [1.10, 1.11, 1.12] [default: 1.12]
   --help                         Show this help")
 
 


### PR DESCRIPTION
Now that clojure 1.12 has gone gold:
- reduce native image test to 1.12 only (was 1.11 and 1.12)
- whereever we were specifying 1.11 specify 1.12 instead