### PR TITLE
test & ci: bump deps

### DIFF
--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,1 +1,5 @@
-{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}
+{:hooks
+ {:analyze-call
+  {taoensso.encore/defalias    taoensso.encore/defalias
+   taoensso.encore/defn-cached taoensso.encore/defn-cached
+   taoensso.encore/defonce     taoensso.encore/defonce}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,16 +1,51 @@
 (ns taoensso.encore
+  "I don't personally use clj-kondo, so these hooks are
+  kindly authored and maintained by contributors.
+  PRs very welcome! - Peter Taoussanis"
+  (:refer-clojure :exclude [defonce])
   (:require
    [clj-kondo.hooks-api :as hooks]))
 
-(defn defalias [{:keys [node]}]
+(defn defalias
+  [{:keys [node]}]
   (let [[sym-raw src-raw] (rest (:children node))
-        src (if src-raw src-raw sym-raw)
-        sym (if src-raw
-              sym-raw
-              (symbol (name (hooks/sexpr src))))]
-    {:node (with-meta
-             (hooks/list-node
-               [(hooks/token-node 'def)
-                (hooks/token-node (hooks/sexpr sym))
-                (hooks/token-node (hooks/sexpr src))])
-             (meta src))}))
+        src (or src-raw sym-raw)
+        sym (if src-raw sym-raw (symbol (name (hooks/sexpr src))))]
+    {:node
+     (with-meta
+       (hooks/list-node
+         [(hooks/token-node 'def)
+          (hooks/token-node (hooks/sexpr sym))
+          (hooks/token-node (hooks/sexpr src))])
+       (meta src))}))
+
+(defn defn-cached
+  [{:keys [node]}]
+  (let [[sym _opts binding-vec & body] (rest (:children node))]
+    {:node
+     (hooks/list-node
+       (list
+         (hooks/token-node 'def)
+         sym
+         (hooks/list-node
+           (list*
+             (hooks/token-node 'fn)
+             binding-vec
+             body))))}))
+
+(defn defonce
+  [{:keys [node]}]
+  ;; args = [sym doc-string? attr-map? init-expr]
+  (let [[sym & args] (rest (:children node))
+        [doc-string args]    (if (and (hooks/string-node? (first args)) (next args)) [(hooks/sexpr (first args)) (next  args)] [nil        args])
+        [attr-map init-expr] (if (and (hooks/map-node?    (first args)) (next args)) [(hooks/sexpr (first args)) (fnext args)] [nil (first args)])
+
+        attr-map (if doc-string (assoc attr-map :doc doc-string) attr-map)
+        sym+meta (if attr-map (with-meta sym attr-map) sym)
+        rewritten
+        (hooks/list-node
+          [(hooks/token-node 'clojure.core/defonce)
+           sym+meta
+           init-expr])]
+
+    {:node rewritten}))

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -20,9 +20,9 @@ jobs:
         run: bb test-coverage
 
       - name: Upload Code Coverage Results
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true # optional (default = false)
-          file: ./target/coverage/codecov.json
+          files: ./target/coverage/codecov.json
           token: ${{ secrets.CODECOV_TOKEN }} # required
           verbose: true # optional (default = false)

--- a/.github/workflows/libs-test.yml
+++ b/.github/workflows/libs-test.yml
@@ -55,7 +55,7 @@ jobs:
       ## instead of using lein bundled with github actions image.
       ## Upcoming 2.11.2 might fix, can optionally revisit in the future.
       - name: Install Lein
-        uses: DeLaGuardo/setup-clojure@12.5
+        uses: DeLaGuardo/setup-clojure@13.0
         with:
           lein: 2.10.0
 

--- a/.github/workflows/native-image-test.yml
+++ b/.github/workflows/native-image-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, ubuntu, macos ]
-        java-version: [ '23' ]
+        java-version: [ '23.0.1' ]
         test: [ native, native-sci ]
         clojure-version: [ '1.12' ]
 

--- a/.github/workflows/shared-setup/action.yml
+++ b/.github/workflows/shared-setup/action.yml
@@ -39,25 +39,11 @@ runs:
         java-version: ${{ inputs.jdk }}
       if: inputs.jdk != 'skip'
 
-    - name: Install Babashka
-      uses: DeLaGuardo/setup-clojure@12.5
+    - name: Install Babashka & Clojure
+      uses: DeLaGuardo/setup-clojure@13.0
       with:
         bb: 'latest'
-
-    - name: Install Clojure (windows)
-      # On windows, deps.clj's deps.exe is used in place of clojure to avoid complexities of official clojure install
-      shell: ${{ inputs.shell }}
-      run: |
-       PowerShell -Command "iwr -useb https://raw.githubusercontent.com/borkdude/deps.clj/master/install.ps1 | iex"
-       Rename-Item $HOME\deps.clj\deps.exe clojure.exe
-       echo "$HOME\deps.clj" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      if: runner.os == 'Windows'
-
-    - name: Install Clojure (macos, linux)
-      uses: DeLaGuardo/setup-clojure@12.5
-      with:
         cli: 'latest'
-      if: runner.os != 'Windows'
 
     - name: Tools Versions
       shell: ${{ inputs.shell }}

--- a/bb.edn
+++ b/bb.edn
@@ -8,7 +8,7 @@
         lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         etaoin/etaoin {:mvn/version "1.1.42"}
-        io.github.babashka/neil {:git/tag "v0.3.67" :git/sha "054ca51"}}
+        io.github.babashka/neil {:git/tag "v0.3.68", :git/sha "78ffab1"} }
  :tasks {;; setup
          :requires ([clojure.string :as string]
                     [lread.status-line :as status])

--- a/deps.edn
+++ b/deps.edn
@@ -50,7 +50,7 @@
            ;;
            :lint-cache {:replace-paths ["src"]} ;; when building classpath we want to exclude resources
                                                 ;; so we do not pick up our own clj-kondo config exports
-           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.09.27"}}
+           :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.11.14"}}
                        :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}
                        :main-opts ["-m" "clj-kondo.main"]}
 
@@ -158,7 +158,7 @@
            ;;
            ;; Maintenance support
            ;;
-           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.9.1232"}
+           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.11.1250"}
                                    org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
                                    }
                       :override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -42,13 +42,8 @@ https://scoop.sh/[Scoop] offers an easy way to install tools.
 @littleli is doing a great job  w/maintaining https://github.com/littleli/scoop-clojure[scoop apps for Clojure, Babashka and other tools] and this is how I installed Babashka.
 
 ==== Clojure
-We all choose our own paths, but for me, using https://github.com/borkdude/deps.clj[deps.clj] instead of https://github.com/clojure/tools.deps.alpha/wiki/clj-on-Windows[Clojure's PowerShell Module] offered me no fuss no muss Clojure on Windows and GitHub Actions on Windows.
-I decided to install deps.clj not through scoop but through https://github.com/borkdude/deps.clj#windows[the deps.clj `install.ps1` script].
-This makes it simple to treat `deps.exe` as if it were the official `clojure` via a simple rename:
-
-----
-Rename-Item $HOME\deps.clj\deps.exe clojure.exe
-----
+Now that the Clojure core team is recommends https://github.com/casselc/clj-msi[clj-msi] life is easier.
+If you are not already installing via `clj-msi` on Windows, you'll want to do so.
 
 ==== GraalVM
 You'll have your own preference, but I find it convenient to install GraalVM on Windows via scoop.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "karma-cljs-test": "^0.1.0",
         "karma-junit-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
-        "shadow-cljs": "^2.28.15"
+        "shadow-cljs": "^2.28.19"
       }
     },
     "node_modules/@colors/colors": {
@@ -45,12 +45,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/accepts": {
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true
     },
     "node_modules/assert": {
@@ -288,13 +288,17 @@
       }
     },
     "node_modules/browserify-rsa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
-      "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
       "dev": true,
       "dependencies": {
-        "bn.js": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/browserify-sign": {
@@ -493,9 +497,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -531,9 +535,9 @@
       }
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true
     },
     "node_modules/create-hash": {
@@ -564,25 +568,29 @@
       }
     },
     "node_modules/crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
       "dev": true,
       "dependencies": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/custom-event": {
@@ -690,9 +698,9 @@
       }
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true
     },
     "node_modules/dom-serialize": {
@@ -724,9 +732,9 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -739,9 +747,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -760,9 +768,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
+      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -770,7 +778,7 @@
         "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "~0.4.1",
+        "cookie": "~0.7.2",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
@@ -1522,9 +1530,9 @@
       }
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true
     },
     "node_modules/mime": {
@@ -1670,9 +1678,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -1840,9 +1848,9 @@
       }
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
       "dev": true
     },
     "node_modules/punycode": {
@@ -2094,9 +2102,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.28.15",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.28.15.tgz",
-      "integrity": "sha512-yK5QDwtOixKAo3WqgMd+0SP7HI2/YvQ5CpwtvwEScqHUqysz/1P6xQrFtGttCcAT2Zo32UuJxD8rCMoqBuwprw==",
+      "version": "2.28.19",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.28.19.tgz",
+      "integrity": "sha512-V8uOuTK2p51URLErZyCl15efMYo9+IIuluMc9XIBmSdFzfENaZfNE7ckLR9yiejr4d3UBtiVmkXxuGqCjDxt9A==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -2138,16 +2146,16 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
-      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.5.2",
+        "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
       },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "karma-cljs-test": "^0.1.0",
     "karma-junit-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
-    "shadow-cljs": "^2.28.15"
+    "shadow-cljs": "^2.28.19"
   }
 }

--- a/script/ci_unit_tests.clj
+++ b/script/ci_unit_tests.clj
@@ -19,10 +19,10 @@
     "ubuntu"))
 
 ;; matrix params to be used on ci
-(def ^:private os-jdks {"ubuntu" ["8" "11" "17" "21"]
+(def ^:private os-jdks {"ubuntu" ["8" "11" "17" "21" "23"]
                         ;; macOS on GitHub Actions is now arm-based and does not include jdk8
-                        "macos"   ["11" "17" "21"]
-                        "windows" ["8" "11" "17" "21"]})
+                        "macos"   ["11" "17" "21" "23"]
+                        "windows" ["8" "11" "17" "21" "23"]})
 (def ^:private all-oses (keys os-jdks))
 
 (defn- test-tasks []

--- a/script/publish.clj
+++ b/script/publish.clj
@@ -162,9 +162,9 @@
                  ;; followed by any attributes
                  "$1"
                   ;; followed by datestamp
-                 (str " - " (yyyy-mm-dd-now-utc))
+                 " - " (yyyy-mm-dd-now-utc)
                   ;; followed by an AsciiDoc anchor for easy referencing
-                 (str " [[v" version  "]]")
+                 " [[v" version  "]]"
                   ;; followed by section content
                  "$2"
                   ;; followed by link to commit log

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -292,7 +292,7 @@
             :show-deps-fn lein-deps-tree
             :test-cmds ["lein kaocha"]}
            {:name "antq"
-            :version "2.9.1232"
+            :version "2.11.1250"
             :platforms [:clj]
             :github-release {:repo "liquidz/antq"}
             :patch-fn deps-edn-v1-patch
@@ -307,7 +307,7 @@
             :show-deps-fn cli-deps-tree
             :test-cmds ["clojure -M:test"]}
            {:name "clerk"
-            :version "0.16.1016"
+            :version "0.17.1102"
             :platforms [:clj]
             :github-release {:repo "nextjournal/clerk"
                              :via :tag
@@ -324,7 +324,7 @@
             :show-deps-fn cli-deps-tree
             :test-cmds ["clojure -T:build ci"]}
            {:name "cljfmt"
-            :version "0.12.0"
+            :version "0.13.0"
             :platforms [:clj :cljs]
             :root "cljfmt"
             :github-release {:repo "weavejester/cljfmt"
@@ -343,7 +343,7 @@
                         "bin/test unit"]}
            {:name "clojure-lsp"
             :platforms [:clj]
-            :version "2024.08.05-18.16.00"
+            :version "2024.11.08-17.49.29"
             :github-release {:repo "clojure-lsp/clojure-lsp"}
             :patch-fn clojure-lsp-patch
             :show-deps-fn clojure-lsp-deps
@@ -439,7 +439,7 @@
             :show-deps-fn cli-deps-tree
             :test-cmds ["bb test-clj"]}
            {:name "splint"
-            :version "1.17.1"
+            :version "1.18.0"
             :platforms [:clj]
             :github-release {:repo "NoahTheDuke/splint"
                              :version-prefix "v"}


### PR DESCRIPTION
Of note:
- codecov action renamed arg file->files
- setup-clojure action now installs via clj-msi on Windows (woot!)
- new version of kondo; it found a couple of redundant nested calls (fixed)!
- bump lib tests libs
- add jdk23 to ci testing