### PR TITLE
ci: planck on ubuntu noble

### DIFF
--- a/.github/workflows/setup-planck/action.yml
+++ b/.github/workflows/setup-planck/action.yml
@@ -23,10 +23,10 @@ runs:
         sudo add-apt-repository -y "deb http://security.ubuntu.com/ubuntu focal-security main"
 
         # is missing after installing planck so compensate
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libicu66
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y libicu66 libjavascriptcoregtk-4.0-18
 
         wget https://launchpad.net/~mfikes/+archive/ubuntu/planck/+files/planck_2.25.0-1ppa1~focal1_amd64.deb
-          sudo apt-get install ./planck_2.25.0-1ppa1~focal1_amd64.deb
+        sudo apt-get install ./planck_2.25.0-1ppa1~focal1_amd64.deb
       if: runner.os == 'Linux'
 
     - name: Planck version (macos, linux)


### PR DESCRIPTION
GitHub Actions has bumped ubuntu to v24.04.

Planck has not released new binaries since ubuntu 2020. https://launchpad.net/~mfikes/+archive/ubuntu/planck

So we need to hack a bit.