### PR TITLE
paredit/join fn fixes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,9 +30,9 @@ A release with known breaking changes is marked with:
 ** `pos` arguments now accept vector `[row col]` in addition to map `{:row :col}`
 {issue}344[#344] ({lread})
 ** `join` now takes type of left sequences
-{issue}321[321] ({lread}, thanks for the issue {person}openvest[@openvest]!)
+{issue}321[#321] ({lread}, thanks for the issue {person}openvest[@openvest]!)
 ** `join` no longer removes comments that were between joined strings
-{issue}351[351] ({lread})
+{issue}351[#351] ({lread})
 
 === v1.1.49 - 2024-11-18 [[v1.1.49]]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,7 +29,7 @@ A release with known breaking changes is marked with:
 * `rewrite.clj.paredit`
 ** `pos` arguments now accept vector `[row col]` in addition to map `{:row :col}`
 {issue}344[#344] ({lread})
-** `join` now takes type of left sequences
+** `join` now takes type of left sequence
 {issue}321[#321] ({lread}, thanks for the issue {person}openvest[@openvest]!)
 ** `join` no longer removes comments that were between joined strings
 {issue}351[#351] ({lread})

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,10 @@ A release with known breaking changes is marked with:
 * `rewrite.clj.paredit`
 ** `pos` arguments now accept vector `[row col]` in addition to map `{:row :col}`
 {issue}344[#344] ({lread})
+** `join` now takes type of left sequences
+{issue}321[321] ({lread}, thanks for the issue {person}openvest[@openvest]!)
+** `join` no longer removes comments that were between joined strings
+{issue}351[351] ({lread})
 
 === v1.1.49 - 2024-11-18 [[v1.1.49]]
 

--- a/test/rewrite_clj/paredit_test.cljc
+++ b/test/rewrite_clj/paredit_test.cljc
@@ -214,7 +214,7 @@
   ;; for this pos fn test, ⊚ in `s` represents character row/col the the `pos`
   ;; ⊚ in `expected` is at zipper node granularity
   (doseq [[s                              expected]
-          [["(\"Hello ⊚World\")"          "(⊚\"Hello \" \"World\")" ]]]
+          [["(\"Hello ⊚World\")"          "(⊚\"Hello \" \"World\")"]]]
     (let [{:keys [pos s]} (th/pos-and-s s)
           zloc (z/of-string* s {:track-position? true})]
       (doseq [pos [pos [(:row pos) (:col pos)]]]
@@ -226,9 +226,18 @@
     (testing (zipper-opts-desc opts)
       (doseq [[s                                                            expected]
               [["[1 2]⊚ [3 4]"                                              "[1 2 ⊚3 4]"]
-               ["\n[[1 2]⊚ ; the first stuff\n [3 4] ; the second stuff\n]" "\n[[1 2 ; the first stuff\n ⊚3 4]; the second stuff\n]"]
+               ["#{1 2} ⊚[3 4]"                                             "#{1 2 ⊚3 4}"]
+               ["(1 2)⊚ {3 4}"                                              "(1 2 ⊚3 4)"]
+               ["{:a 1} ⊚(:b 2)"                                            "{:a 1 ⊚:b 2}"]
+               ["[foo]⊚[bar]"                                               "[foo ⊚bar]"]
+               ["[foo]   ⊚[bar]"                                            "[foo   ⊚bar]"]
+               ["\n[[1 2]⊚ ; the first stuff\n [3 4] ; the second stuff\n]" "\n[[1 2 ; the first stuff\n ⊚3 4] ; the second stuff\n]"]
                ;; strings
-               ["(\"Hello \" ⊚\"World\")"                                   "(⊚\"Hello World\")"]]]
+               ["(\"Hello \" ⊚\"World\")"                                   "(⊚\"Hello World\")"]
+               ["(⊚\"Hello \" \"World\")" "(⊚\"Hello \" \"World\")"]
+               ["(\"Hello \" ;; comment\n;; comment2\n⊚\"World\")"
+                "(⊚\"Hello World\" ;; comment\n;; comment2\n)"]
+               ["\"foo\"⊚\"bar\""         "⊚\"foobar\""]]]
         (let [zloc (th/of-locmarked-string s opts)]
           (is (= s (th/root-locmarked-string zloc)) "(sanity) string before")
           (is (= expected (-> zloc pe/join th/root-locmarked-string)) "string after"))))))


### PR DESCRIPTION
- rewritten to not use internal `global-find-by-node` (contributes to #256)
- now takes type of left sequence (closes #321)
- no longer removes comments between strings when joining 2 strings (closes #351)