### PR TITLE
paredit: split-at-pos no longer throws @ str quote

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,8 @@ A release with known breaking changes is marked with:
 {issue}321[#321] ({lread}, thanks for the issue {person}openvest[@openvest]!)
 ** `join` no longer removes comments that were between joined strings
 {issue}351[#351] ({lread})
+** `split-at-pos` no longer throws on split at string opening quote
+{issue}350[#350] ({lread})
 
 === v1.1.49 - 2024-11-18 [[v1.1.49]]
 

--- a/src/rewrite_clj/paredit.cljc
+++ b/src/rewrite_clj/paredit.cljc
@@ -446,19 +446,22 @@
                              (update-in [0] #(subs % split-col))))))))
 
 (defn split-at-pos
-  "In string aware split
-
-  Perform split at given position `pos` Like split, but if inside string splits string into two strings.
+  "In-string aware split. Returns `zloc` with node found at `pos` split.
+  If `pos` is inside a string, splits string into two strings else calls [[split]].
 
   - `zloc` location is (inclusive) starting point for `pos` depth-first search
   - `pos` can be a `{:row :col}` map or a `[row col]` vector. The `row` and `col` values are
   1-based and relative to the start of the source code the zipper represents.
 
-  Throws if `zloc` was not created with [position tracking](/doc/01-user-guide.adoc#position-tracking)."
+  Throws if `zloc` was not created with [position tracking](/doc/01-user-guide.adoc#position-tracking).
+
+  - `[1 2 |3 4 5]       => [1 2 |3] [4 5]`
+  - `(\"Hello |World\") => (|\"Hello\" \"World\")`"
   [zloc pos]
   (if-let [candidate (z/find-last-by-pos zloc pos)]
-    (let [pos (fz/pos-as-map pos)]
-      (if (string-node? candidate)
+    (let [pos (fz/pos-as-map pos)
+          candidate-pos (fz/pos-as-map (-> candidate z/position fz/pos-as-map))]
+      (if (and (string-node? candidate) (not= pos candidate-pos))
         (split-string candidate pos)
         (split candidate)))
     zloc))

--- a/test/rewrite_clj/paredit_test.cljc
+++ b/test/rewrite_clj/paredit_test.cljc
@@ -213,8 +213,11 @@
 (deftest split-at-pos-test
   ;; for this pos fn test, ⊚ in `s` represents character row/col the the `pos`
   ;; ⊚ in `expected` is at zipper node granularity
-  (doseq [[s                              expected]
-          [["(\"Hello ⊚World\")"          "(⊚\"Hello \" \"World\")"]]]
+  (doseq [[s                                       expected]
+          [["(\"Hello ⊚World\" 42)"                "(⊚\"Hello \" \"World\" 42)"]
+           ["(\"⊚Hello World\" 101)"               "(⊚\"\" \"Hello World\" 101)"]
+           ["(\"H⊚ello World\" 101)"               "(⊚\"H\" \"ello World\" 101)"]
+           ["(⊚\"Hello World\" 101)"               "(⊚\"Hello World\") (101)"]]]
     (let [{:keys [pos s]} (th/pos-and-s s)
           zloc (z/of-string* s {:track-position? true})]
       (doseq [pos [pos [(:row pos) (:col pos)]]]


### PR DESCRIPTION
`split-at-pos` no longer throws when attempting to split at string's opening quote.

Closes #350