### PR TITLE
paredit: kill-one-at-pos: word in string fix

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,8 @@ A release with known breaking changes is marked with:
 {issue}351[#351] ({lread})
 ** `split-at-pos` no longer throws on split at string opening quote
 {issue}350[#350] ({lread})
+** `kill-one-at-pos` word deletion in string/comment off-by-one error fixed
+{issue}343[#343] ({lread})
 
 === v1.1.49 - 2024-11-18 [[v1.1.49]]
 

--- a/src/rewrite_clj/zip/removez.cljc
+++ b/src/rewrite_clj/zip/removez.cljc
@@ -85,6 +85,20 @@
                     left-ws-trim
                     right-ws-trim-keep-trailing-linebreak))
 
+(defn remove-and-move-left
+  "Return `zloc` with current node removed, and located to node left of removed node.
+  If no left node, returns `nil`.
+
+  Currently internal, and likely not generic enough to expose, review update as necessary should we want to expose to public API."
+  [zloc]
+  (when (m/left zloc)
+    (->> zloc
+         left-ws-trim
+         right-ws-trim
+         u/remove-and-move-left
+         ;; TODO: needed?
+         (ws/skip-whitespace zraw/left))))
+
 (defn remove-preserve-newline
   "Same as [[remove]] but preserves newlines.
    Specifically: will trim all whitespace - or whitespace up to first linebreak if present."


### PR DESCRIPTION
In-string handling now:
- no-op if pos does not locate to word (i.e. whitespace)
- no longer has off-by-one error for word deletion

Closes #343

Also contributes to #256