### PR TITLE
paredit: slurp fixes

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -26,7 +26,12 @@
   :unused-referred-var
   {:exclude {clojure.test.check [quick-check]}}
   :deprecated-var
-  {:exclude {rewrite-clj.zip.base/->string
+  {:exclude {rewrite-clj.paredit/slurp-forward        {:namespaces [rewrite-clj.paredit-test]}
+             rewrite-clj.paredit/slurp-forward-fully  {:namespaces [rewrite-clj.paredit-test]}
+             rewrite-clj.paredit/slurp-backward       {:namespaces [rewrite-clj.paredit-test]}
+             rewrite-clj.paredit/slurp-backward-fully {:namespaces [rewrite-clj.paredit-test]}
+
+             rewrite-clj.zip.base/->string
              {:namespaces [rewrite-clj.zip]}
              rewrite-clj.zip.base/->root-string
              {:namespaces [rewrite-clj.zip]}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,38 @@ A release with known breaking changes is marked with:
 {issue}350[#350] ({lread})
 ** `kill-one-at-pos` word deletion in string/comment off-by-one error fixed
 {issue}343[#343] ({lread})
+** Address design flaw of `slurp` functions
++
+|===
+| Deprecated | Replacement
+
+| `slurp-forward`
+| `slurp-forward-into`
+
+| `slurp-forward-fully`
+| `slurp-forward-fully-into`
+
+| `slurp-backward`
+| `slurp-backward-into`
+
+| `slurp-backward-fully`
+| `slurp-backward-fully-into`
+|===
+{issue}339[#339] ({lread})
+** stop adding space char when preserving slurped newlines
+{issue}345[#345] ({lread})
+** review ambiguous `-slurp-`*`-fully` fn behaviour
+{issue}341[#341] ({lread})
+** when slurping don't consider a node with `#_ uneval` nodes empty
+{issue}338[#338] ({lread})
+** when slurping don't throw on rewrite-clj parseable, but invalid clojure, i.e., `{:a}`
+{issue}336[#336] ({lread})
+** slurping forward fully no longer throws when slurping into an empty seq that is the last item in a seq
+{issue}335[#335] ({lread})
+** slurping backward at empty-seq at start of a seq no longer throws
+{issue}334[#334] ({lread})
+** slurping forward now slurps when at empty seq at end of a seq
+{issue}333[#333] ({lread})
 
 === v1.1.49 - 2024-11-18 [[v1.1.49]]
 

--- a/deps.edn
+++ b/deps.edn
@@ -71,7 +71,8 @@
                                                         ;; we rely on clj-kondo for that
                                                         :ignored-faults {:deprecations {rewrite-clj.regression-test true
                                                                                         rewrite-clj.zip.whitespace-test true
-                                                                                        rewrite-clj.zip-test true}}}]}
+                                                                                        rewrite-clj.zip-test true
+                                                                                        rewrite-clj.paredit-test true}}}]}
 
            ;;
            ;; Test support

--- a/src/rewrite_clj/custom_zipper/core.cljc
+++ b/src/rewrite_clj/custom_zipper/core.cljc
@@ -101,6 +101,11 @@
   [zloc]
   (map first (:left zloc)))
 
+(defn-switchable rights
+  "Returns a seq of the left siblings of current node in `zloc`."
+  [zloc]
+  (map first (:right zloc)))
+
 (defn-switchable down
   "Returns zipper with the location at the leftmost child of current node in `zloc`, or
   nil if no children."


### PR DESCRIPTION
Because of #256, slurp fns had to be rewritten. During rewriting:

- address design flaw by deprecating existing `slurp` fns and adding replacement `slurp-`*`-into` fns (closes #339)
- stop adding space char when preserving slurped newlines (closes #345)
- review ambiguous `-slurp-`*-`fully` fn behaviour (closes #341)
- when slurping, don't consider a node with `#_` uneval nodes empty (closes #338)
- don't throw on rewrite-clj parseable but invalid clojure `{:a}` (closes #336)
- slurping forward fully no longer throws when slurping into an empty seq that is last item in a seq (closes #335)
- slurping backward at empty-seq at start of seq no longer throws (closes #334)
- slurp forward now slurps when at empty-seq at end of seq (closes #333)