### PR TITLE
paredit: kill-*at-pos end of string/seq handling

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -69,6 +69,8 @@ A release with known breaking changes is marked with:
 {issue}334[#334] ({lread})
 ** slurping forward now slurps when at empty seq at end of a seq
 {issue}333[#333] ({lread})
+** when `pos` is at closing `"`,`)` `]`, etc `kill-at-pos`, `kill-one-at-pos` now kill the found node
+{issue}362[#362] ({lread})
 
 === v1.1.49 - 2024-11-18 [[v1.1.49]]
 


### PR DESCRIPTION
When `pos` is at end of string marker `"` or end of sequence marker `]`, `)` etc, kill the node.

Closes #362

Rewrite of `kill-at-pos` contributes to #256