### PR TITLE
Bump clojure/tools.reader to v1.5.2

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,7 +26,7 @@ A release with known breaking changes is marked with:
 
 * `rewrite-clj.zip/insert-right` and `rewrite-clj.zip/append-child` no longer insert a space when inserting/appending after a comment node.
 {issue}346[#346] ({lread})
-* `:end-col` metadata now correct for keywords at end of content
+* bump `clojure/tools.reader` to correct `:end-col` metadata for keywords at end of content
 {issue}367[#367] ({lread})
 * `rewrite.clj.paredit`
 ** now supports paredit ops on new/changed nodes in a zipper

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps {org.clojure/clojure {:mvn/version "1.8.0"}
-        org.clojure/tools.reader {:mvn/version "1.5.1"}}
+        org.clojure/tools.reader {:mvn/version "1.5.2"}}
 
  :aliases {;; we use babashka/neil for project attributes
            ;; publish workflow references these values (and automatically bumps patch component of version)

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -158,7 +158,7 @@
  (patch-deps {:filename (str (fs/file home-dir "project.clj"))
               ;; we remove and add tools.reader because project.clj has pedantic? :abort enabled
               :removals #{'rewrite-clj 'org.clojure/tools.reader}
-              :additions [['org.clojure/tools.reader "1.5.1"]
+              :additions [['org.clojure/tools.reader "1.5.2"]
                           ['rewrite-clj rewrite-clj-version]]}))
 
 ;;
@@ -194,7 +194,7 @@
         (string/replace #"rewrite-clj \"(\d+\.)+.*\""
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.5.1\"")
+                        "org.clojure/tools.reader \"1.5.2\"")
         (->> (spit p)))))
 
 ;;
@@ -228,7 +228,7 @@
                         (format "rewrite-clj \"%s\"" rewrite-clj-version))
         ;; pedantic is enabled for CI, so adjust to match rewrite-clj so we don't fail
         (string/replace #"org.clojure/tools.reader \"(\d+\.)+.*\""
-                        "org.clojure/tools.reader \"1.5.1\"")
+                        "org.clojure/tools.reader \"1.5.2\"")
         (->> (spit p)))))
 
 ;;


### PR DESCRIPTION
We always bump to current to make sure we work with current.

This latest version fixes metadata for numbers at end of content (which rewrite-clj was unnaffected by).