### PR TITLE
test-libs: bump clojure-lsp

### DIFF
--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -344,7 +344,7 @@
                         "bin/test unit"]}
            {:name "clojure-lsp"
             :platforms [:clj]
-            :version "2025.02.07-16.11.24"
+            :version "2025.03.07-17.42.36"
             :github-release {:repo "clojure-lsp/clojure-lsp"}
             :patch-fn clojure-lsp-patch
             :show-deps-fn clojure-lsp-deps


### PR DESCRIPTION
Hmm... clojure-lsp is using a sha reference to rewrite-clj. But our test-libs handles that fine.
And... maybe I should try to finish up my paredit fixes and cut a release, eh?