### PR TITLE
test & ci: bump deps

### DIFF
--- a/.clj-kondo/imports/taoensso/encore/config.edn
+++ b/.clj-kondo/imports/taoensso/encore/config.edn
@@ -1,5 +1,6 @@
 {:hooks
  {:analyze-call
-  {taoensso.encore/defalias    taoensso.encore/defalias
-   taoensso.encore/defn-cached taoensso.encore/defn-cached
-   taoensso.encore/defonce     taoensso.encore/defonce}}}
+  {taoensso.encore/defalias    taoensso.encore-hooks/defalias
+   taoensso.encore/defaliases  taoensso.encore-hooks/defaliases
+   taoensso.encore/defn-cached taoensso.encore-hooks/defn-cached
+   taoensso.encore/defonce     taoensso.encore-hooks/defonce}}}

--- a/.clj-kondo/imports/taoensso/encore/taoensso/encore_hooks.clj
+++ b/.clj-kondo/imports/taoensso/encore/taoensso/encore_hooks.clj
@@ -1,0 +1,82 @@
+(ns taoensso.encore-hooks
+  "I don't personally use clj-kondo, so these hooks are
+  kindly authored and maintained by contributors.
+  PRs very welcome! - Peter Taoussanis"
+  (:refer-clojure :exclude [defonce])
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias
+  [{:keys [node]}]
+  (let [[alias src-raw _attrs body] (rest (:children node))
+        src (or src-raw alias)
+        sym (if src-raw (hooks/sexpr alias) (symbol (name (hooks/sexpr src))))]
+    {:node
+     (with-meta
+       (hooks/list-node
+        [(hooks/token-node 'def)
+         (hooks/token-node sym)
+         (if body
+           (hooks/list-node
+            ;; use :body in the def to avoid unused import/private var warnings
+            [(hooks/token-node 'or) body src])
+           src)])
+       (meta src))}))
+
+(defn defaliases
+  [{:keys [node]}]
+  (let [alias-nodes (rest (:children node))]
+    {:node
+     (hooks/list-node
+      (into
+       [(hooks/token-node 'do)]
+       (map
+        (fn alias->defalias [alias-node]
+          (cond
+            (hooks/token-node? alias-node)
+            (hooks/list-node
+             [(hooks/token-node 'taoensso.encore/defalias)
+              alias-node])
+
+            (hooks/map-node? alias-node)
+            (let [{:keys [src alias attrs body]} (hooks/sexpr alias-node)
+                  ;; workaround as can't seem to (get) using a token-node
+                  ;; and there's no update-keys (yet) in sci apparently
+                  [& {:as node-as-map}] (:children alias-node)
+                  {:keys [attrs body]} (zipmap (map hooks/sexpr (keys node-as-map))
+                                               (vals node-as-map))]
+              (hooks/list-node
+               [(hooks/token-node 'taoensso.encore/defalias)
+                (or alias src) (hooks/token-node src) attrs body])))))
+       alias-nodes))}))
+
+(defn defn-cached
+  [{:keys [node]}]
+  (let [[sym _opts binding-vec & body] (rest (:children node))]
+    {:node
+     (hooks/list-node
+       (list
+         (hooks/token-node 'def)
+         sym
+         (hooks/list-node
+           (list*
+             (hooks/token-node 'fn)
+             binding-vec
+             body))))}))
+
+(defn defonce
+  [{:keys [node]}]
+  ;; args = [sym doc-string? attr-map? init-expr]
+  (let [[sym & args] (rest (:children node))
+        [doc-string args]    (if (and (hooks/string-node? (first args)) (next args)) [(hooks/sexpr (first args)) (next  args)] [nil        args])
+        [attr-map init-expr] (if (and (hooks/map-node?    (first args)) (next args)) [(hooks/sexpr (first args)) (fnext args)] [nil (first args)])
+
+        attr-map (if doc-string (assoc attr-map :doc doc-string) attr-map)
+        sym+meta (if attr-map (with-meta sym attr-map) sym)
+        rewritten
+        (hooks/list-node
+          [(hooks/token-node 'clojure.core/defonce)
+           sym+meta
+           init-expr])]
+
+    {:node rewritten}))

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
            {;; for disabling the official compiler
             :classpath-overrides {org.clojure/clojure nil}
             :extra-deps {com.github.flow-storm/clojure {:mvn/version "1.12.1"}
-                         com.github.flow-storm/flow-storm-dbg {:mvn/version "4.4.5"}}
+                         com.github.flow-storm/flow-storm-dbg {:mvn/version "4.4.6"}}
             :jvm-opts ["-Dclojure.storm.instrumentEnable=true"]}
 
            :nrepl/jvm
@@ -130,7 +130,7 @@
                                  cli-matic/cli-matic {:mvn/version "0.5.4"}}}
 
            :apply-import-vars {:override-deps {org.clojure/clojure {:mvn/version "1.12.1"}}
-                               :extra-deps {metosin/malli {:mvn/version "0.18.0"}
+                               :extra-deps {metosin/malli {:mvn/version "0.19.1"}
                                             io.aviso/pretty {:mvn/version "1.4.4"}}
                                :ns-default lread.apply-import-vars}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "karma-cljs-test": "^0.1.0",
         "karma-junit-reporter": "^2.0.0",
         "karma-spec-reporter": "^0.0.36",
-        "shadow-cljs": "^3.1.5"
+        "shadow-cljs": "^3.1.7"
       }
     },
     "node_modules/@colors/colors": {
@@ -32,9 +32,9 @@
       "license": "MIT"
     },
     "node_modules/@types/cors": {
-      "version": "2.8.18",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.18.tgz",
-      "integrity": "sha512-nX3d0sxJW41CqQvfOzVG1NCTXfFDrDWIghCZncpHeWlVFd81zxB/DLhg7avFg6eHLCRX7ckBmoIIcqa++upvJA==",
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -42,13 +42,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.27.tgz",
-      "integrity": "sha512-5fF+eu5mwihV2BeVtX5vijhdaZOfkQTATrePEaXTcKqI16LhJ7gi2/Vhd9OZM0UojcdmiOCVg5rrax+i1MdoQQ==",
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/accepts": {
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1632,9 +1632,9 @@
       "license": "ISC"
     },
     "node_modules/shadow-cljs": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.1.5.tgz",
-      "integrity": "sha512-0uOUTt/iBe1grXuA/u9PHgLBYyjRcuTOMm80c+iVVvvHPngz2e6yRFfWJcU9h9dYmJAIafQhKLgnxfaoKefpfQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-3.1.7.tgz",
+      "integrity": "sha512-q1SCy5m5EpNfrn6C0vKa2ho6gwW6rdSU1Ge22HbbZ813TpR/1hBXdlgTF2RE49yIqJxxhVtfcLz0jWa0Ul32IQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2077,9 +2077,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "karma-cljs-test": "^0.1.0",
     "karma-junit-reporter": "^2.0.0",
     "karma-spec-reporter": "^0.0.36",
-    "shadow-cljs": "^3.1.5"
+    "shadow-cljs": "^3.1.7"
   }
 }

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -329,14 +329,14 @@
                         "bin/test unit"]}
            {:name "clojure-lsp"
             :platforms [:clj]
-            :version "2025.06.06-19.04.49"
+            :version "2025.06.13-20.45.44"
             :github-release {:repo "clojure-lsp/clojure-lsp"}
             :patch-fn clojure-lsp-patch
             :show-deps-fn clojure-lsp-deps
             :test-cmds ["bb test"]}
            {:name "clojure-mcp"
             :platforms [:clj]
-            :version "0.1.1-alpha"
+            :version "0.1.4-alpha"
             :github-release {:repo "bhauman/clojure-mcp"
                              :via :tag
                              :version-prefix "v"}


### PR DESCRIPTION
Why the update to .clj-kondo/imports? Pretty sure these are brought down by clojure-lsp which brings down imports for bb included deps and there was recently a new bb version release.