### PR TITLE
test & dev: bump deps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,10 +46,10 @@ Some projects using rewrite-clj v1
 * https://github.com/fabricate-site/adorn[adorn] {canary-tested} - Extensible conversion of Clojure code to Hiccup forms
 * https://github.com/xsc/ancient-clj[ancient-clj] {canary-tested} - Version Metadata Retrieval for Maven Artifacts
 * https://github.com/liquidz/antq[antq] {canary-tested} - Point out your outdated dependencies
-// we already do sci testing and borkdude runs his own copies of rewrite-clj tests against bb:
+// we already do sci testing and borkdude runs his own copies of rewrite-clj tests against babashka:
 * https://github.com/babashka/babashka[babashka] {not-canary-tested} - Native, fast starting Clojure interpreter for scripting
 * https://github.com/borkdude/carve[carve] {canary-tested} - Carve out the essentials of your Clojure app
-// no unit tests:
+// classpath has no unit tests:
 * https://github.com/lambdaisland/classpath[classpath] {not-canary-tested} - Classpath/classloader/deps.edn related utilities
 * https://github.com/nextjournal/clerk[clerk] {canary-tested} - Local-First Notebooks for Clojure
 * https://github.com/kurtharriger/clj-mergetool[clj-mergetool] {canary-tested} - Smarter git mergetool for clojure and edn
@@ -57,10 +57,12 @@ Some projects using rewrite-clj v1
 * https://github.com/greglook/cljstyle[cljstyle] {canary-tested} - A tool for formatting Clojure code
 * https://github.com/clojure-lsp/clojure-lsp[clojure-lsp] {canary-tested} - Language Server (LSP) for Clojure
 * https://github.com/bhauman/clojure-mcp[clojure-mcp] {canary-tested} - REPL-Driven Development with AI Assistance
-// repo is not version tagged:
+// depot tests are currently broken
+* https://github.com/Olical/depot[depot] {not-canary-tested} - Find newer versions of your dependencies in your deps.edn file
+// duck-repled repo is not version tagged:
 * https://github.com/mauricioszabo/duck-repled[duck-repled] {not-canary-tested} - Transform your REPL interation into Pathom queries
 * https://github.com/jonase/kibit[kibit] {canary-tested} - There's a function for that!
-// repo is not version tagged:
+// kit repo is not version tagged:
 * https://github.com/kit-clj/kit[kit] {not-canary-tested} - Lightweight, modular framework for scalable web development in Clojure
 * https://github.com/FiV0/kusonga[kusonga] {canary-tested} - Renaming and moving namespaces in Clojure(script)
 * https://github.com/clojure-emacs/refactor-nrepl[refactor-nrepl] {not-canary-tested} - nREPL middleware to support refactorings in an editor agnostic way
@@ -74,15 +76,14 @@ Some projects using rewrite-clj v1
 
 Some projects using rewrite-clj v0 and/or rewrite-cljs
 
-* https://github.com/Olical/depot[depot] {canary-tested} {canary-needed-patch} - Find newer versions of your dependencies in your deps.edn file
 // unit tests (unpatched after clone), at time of this writing, are failing for confair
 * https://github.com/magnars/confair[confair] {not-canary-tested} - A configuration library for Clojure
-// tests rely on datomic-pro
+// tests for gen-fn rely on datomic-pro
 * https://github.com/ivarref/gen-fn[gen-fn] {not-canary-tested} - Generate Datomic function literals from regular Clojure namespaces
 * https://github.com/xsc/lein-ancient[lein-ancient] {canary-tested} - Check your Projects for outdated Dependencies
 * https://github.com/benedekfazekas/mranderson[mranderson] {canary-tested} - Dependency inlining and shadowing
 * https://github.com/jstepien/mutant[mutant] {canary-tested} - Mutation testing for Clojure
-// could not easily figure out how to run tests:
+// could not easily figure out how to run tests for repl-tooling:
 * https://github.com/mauricioszabo/repl-tooling[repl-tooling] {not-canary-tested} - a base package for Clojure's editor tooling
 // tests frequently broken, skipping for now:
 * https://github.com/atomist-skills/update-leiningen-dependencies-skill[update-leiningen-dependencies-skill] {not-canary-tested} - Track project.clj dependencies across different projects

--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,7 @@
            ;;
            :nrepl
            {:extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}
-                         cider/cider-nrepl {:mvn/version "0.56.0"}}
+                         cider/cider-nrepl {:mvn/version "0.57.0"}}
             :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]}
 
            :flowstorm

--- a/script/test_libs.clj
+++ b/script/test_libs.clj
@@ -136,7 +136,8 @@
                :removals #{'rewrite-clj 'rewrite-clj/rewrite-clj}
                :additions [['rewrite-clj/rewrite-clj rewrite-clj-version]]}))
 
-(defn- replace-in-file [fname match replacement]
+;; needed by depot patch, we'll see if it still needed after depot fixes its tests
+#_(defn- replace-in-file [fname match replacement]
   (let [orig-filename (str fname ".orig")
         content (slurp fname)]
     (fs/copy fname orig-filename)
@@ -177,7 +178,8 @@
 ;;
 ;; depot
 ;;
-(defn depot-patch [{:keys [home-dir] :as lib}]
+;; We'll see if this custom path is needed after next release of depot that fixes its tests
+#_(defn depot-patch [{:keys [home-dir] :as lib}]
   (deps-edn-v1-patch lib)
   (status/line :detail "=> depot uses but does not require rewrite-clj.node, need to adjust for rewrite-clj v1")
   (replace-in-file (str (fs/file home-dir "src/depot/zip.clj"))
@@ -336,17 +338,17 @@
             :test-cmds ["bb test"]}
            {:name "clojure-mcp"
             :platforms [:clj]
-            :version "0.1.5-alpha"
+            :version "0.1.6-alpha"
             :github-release {:repo "bhauman/clojure-mcp"
                              :via :tag
                              :version-prefix "v"}
             :patch-fn deps-edn-v1-patch
             :show-deps-fn cli-deps-tree
             :test-cmds ["clojure -M:test"]}
-           {:name "depot"
+           #_{:name "depot"
             :platforms [:clj]
-            :note "1 patch required due to using, but not requiring, rewrite-clj.node"
-            :version "2.2.0"
+            :note "Depot tests are currently broken, re-enable when they are fixed"
+            :version "2.4.0"
             :github-release {:repo "Olical/depot"
                              :via :tag
                              :version-prefix "v"}


### PR DESCRIPTION
I disabled lib tests for depot because its current release tests are not passing. See https://github.com/Olical/depot/issues/57

But depot is using rewrite-clj v1 now, so updated README accordingly.