### PR TITLE
Perf: Pass explicit context instead *delimiter* dynvar

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,9 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 === Unreleased
 
+* perf: pass explicit context instead *delimiter* dynvar.
+{issue}442[#442] ({person}alexander-yakushev[@alexander-yakushev])
+
 === v1.2.53 - 2026-03-12 [[v1.2.53]]
 
 * Performance improvements

--- a/src/rewrite_clj/parser/core.cljc
+++ b/src/rewrite_clj/parser/core.cljc
@@ -22,14 +22,17 @@
 
 ;; ## Base Parser
 
-(def ^:dynamic ^:private *delimiter*
-  nil)
+;; This is used to efficiently pass additional context to parsing functions.
+;; Field explanations:
+;; - :delimiter - the expected closing character - `}`, `]` or `)` - to
+;;                correctly match the respective opening character.
+(defrecord ReaderContext [delimiter])
 
 (defn- dispatch
-  [c]
-  (cond (nil? c)               :eof
-        (reader/whitespace? c) :whitespace
-        (= c *delimiter*)      :delimiter
+  [c context]
+  (cond (nil? c)                   :eof
+        (reader/whitespace? c)     :whitespace
+        (= c (:delimiter context)) :delimiter
         :else (get {\^ :meta      \# :sharp
                     \( :list      \[ :vector    \{ :map
                     \} :unmatched \] :unmatched \) :unmatched
@@ -39,83 +42,83 @@
                    c :token)))
 
 (defmulti ^:private parse-next*
-  (comp #'dispatch reader/peek))
+  (fn [reader context] (dispatch (reader/peek reader) context)))
 
 (defn parse-next
-  [#?(:cljs ^not-native reader :default reader)]
-  (reader/read-with-meta reader parse-next*))
+  ([#?(:cljs ^not-native reader :default reader)] (parse-next reader nil))
+  ([#?(:cljs ^not-native reader :default reader) context]
+   (reader/read-with-meta reader parse-next* context)))
 
 ;; # Parser Helpers
 
 (defn- parse-delim
   [#?(:cljs ^not-native reader :default reader) delimiter]
   (reader/ignore reader)
-  (->> #(binding [*delimiter* delimiter]
-          (parse-next %))
-       (reader/read-repeatedly reader)))
+  (reader/read-repeatedly reader parse-next (->ReaderContext delimiter)))
 
 (defn- parse-printables
-  [#?(:cljs ^not-native reader :default reader) node-tag n & [ignore?]]
+  [#?(:cljs ^not-native reader :default reader) context node-tag n & [ignore?]]
   (when ignore?
     (reader/ignore reader))
   (reader/read-n
-    reader
-    node-tag
-    parse-next
-    (complement protocols/printable-only?)
-    n))
+   reader
+   node-tag
+   parse-next
+   context
+   (complement protocols/printable-only?)
+   n))
 
 ;; ## Parser Functions
 
 ;; ### Base
 
 (defmethod parse-next* :token
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (parse-token reader))
 
 (defmethod parse-next* :delimiter
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (reader/ignore reader))
 
 (defmethod parse-next* :unmatched
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (reader/throw-reader
     reader
     "Unmatched delimiter: %s"
     (reader/peek reader)))
 
 (defmethod parse-next* :eof
-  [#?(:cljs ^not-native reader :default reader)]
-  (when *delimiter*
+  [#?(:cljs ^not-native reader :default reader) context]
+  (when (:delimiter context)
     (reader/throw-reader reader "Unexpected EOF.")))
 
 ;; ### Whitespace
 
 (defmethod parse-next* :whitespace
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (parse-whitespace reader))
 
 (defmethod parse-next* :comment
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (reader/ignore reader)
   (comment-node ";" (reader/read-include-linebreak reader)))
 
 ;; ### Special Values
 
 (defmethod parse-next* :keyword
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (parse-keyword reader))
 
 (defmethod parse-next* :string
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (parse-string reader))
 
 ;; ### Meta
 
 (defmethod parse-next* :meta
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) context]
   (reader/ignore reader)
-  (meta-node (parse-printables reader :meta 2)))
+  (meta-node (parse-printables reader context :meta 2)))
 
 ;; ### Reader Specialities
 
@@ -128,7 +131,7 @@
   (comment-node "#!" (reader/read-include-linebreak reader)))
 
 (defmethod parse-next* :sharp
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) context]
   (reader/ignore reader)
   (case (reader/peek reader)
     nil (reader/throw-reader reader "Unexpected EOF.")
@@ -137,17 +140,17 @@
     \{ (set-node (parse-delim reader \}))
     \( (fn-node (parse-delim reader \)))
     \" (regex-node (parse-regex reader))
-    \^ (raw-meta-node (parse-printables reader :meta 2 true))
-    \' (var-node (parse-printables reader :var 1 true))
-    \= (eval-node (parse-printables reader :eval 1 true))
-    \_ (uneval-node (parse-printables reader :uneval 1 true))
+    \^ (raw-meta-node (parse-printables reader context :meta 2 true))
+    \' (var-node (parse-printables reader context :var 1 true))
+    \= (eval-node (parse-printables reader context :eval 1 true))
+    \_ (uneval-node (parse-printables reader context :uneval 1 true))
     \: (parse-namespaced-map reader parse-next)
     \? (do
          ;; we need to examine the next character, so consume one (known \?)
          (reader/next reader)
          ;; we will always have a reader-macro-node as the result
          (reader-macro-node
-          (let [read1 (fn [] (parse-printables reader :reader-macro 1))]
+          (let [read1 (fn [] (parse-printables reader context :reader-macro 1))]
             (cons (case (reader/peek reader)
                     ;; the easy case, just emit a token
                     \( (token-node (symbol "?"))
@@ -160,42 +163,42 @@
                     (do (reader/unread reader \?)
                         (first (read1))))
                   (read1)))))
-    (reader-macro-node (parse-printables reader :reader-macro 2))))
+    (reader-macro-node (parse-printables reader context :reader-macro 2))))
 
 (defmethod parse-next* :deref
-  [#?(:cljs ^not-native reader :default reader)]
-  (deref-node (parse-printables reader :deref 1 true)))
+  [#?(:cljs ^not-native reader :default reader) context]
+  (deref-node (parse-printables reader context :deref 1 true)))
 
 ;; ## Quotes
 
 (defmethod parse-next* :quote
-  [#?(:cljs ^not-native reader :default reader)]
-  (quote-node (parse-printables reader :quote 1 true)))
+  [#?(:cljs ^not-native reader :default reader) context]
+  (quote-node (parse-printables reader context :quote 1 true)))
 
 (defmethod parse-next* :syntax-quote
-  [#?(:cljs ^not-native reader :default reader)]
-  (syntax-quote-node (parse-printables reader :syntax-quote 1 true)))
+  [#?(:cljs ^not-native reader :default reader) context]
+  (syntax-quote-node (parse-printables reader context :syntax-quote 1 true)))
 
 (defmethod parse-next* :unquote
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) context]
   (reader/ignore reader)
   (let [c (reader/peek reader)]
     (if (= c \@)
       (unquote-splicing-node
-        (parse-printables reader :unquote 1 true))
+        (parse-printables reader context :unquote 1 true))
       (unquote-node
-        (parse-printables reader :unquote 1)))))
+        (parse-printables reader context :unquote 1)))))
 
 ;; ### Seqs
 
 (defmethod parse-next* :list
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (list-node (parse-delim reader \))))
 
 (defmethod parse-next* :vector
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (vector-node (parse-delim reader \])))
 
 (defmethod parse-next* :map
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader) _]
   (map-node (parse-delim reader \})))

--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -146,11 +146,11 @@
 
 (defn read-with-meta
   "Use the given function to read value, then attach row/col metadata."
-  [#?(:cljs ^not-native reader :default reader) read-fn]
+  [#?(:cljs ^not-native reader :default reader) read-fn context]
   (loop []
     (let [start-row (r/get-line-number reader)
           start-col (r/get-column-number reader)]
-      (when-let [entry (read-fn reader)]
+      (when-let [entry (read-fn reader context)]
         (if (identical? reader entry)
           (recur)
           ;; conj is more efficient here than into because it doesn't perform
@@ -165,20 +165,21 @@
 (defn read-repeatedly
   "Call the given function on the given reader until it returns
    a non-truthy value."
-  [#?(:cljs ^not-native reader :default reader) read-fn]
-  (->> (repeatedly #(read-fn reader))
-       (take-while identity)
-       (doall)))
+  [#?(:cljs ^not-native reader :default reader) read-fn context]
+  (loop [acc []]
+    (if-let [x (read-fn reader context)]
+      (recur (conj acc x))
+      (or (seq acc) ()))))
 
 (defn read-n
   "Call the given function on the given reader until `n` values matching `p?` have been
    collected."
-  [#?(:cljs ^not-native reader :default reader) node-tag read-fn p? n]
+  [#?(:cljs ^not-native reader :default reader) node-tag read-fn context p? n]
   {:pre [(pos? n)]}
   (loop [c 0
          vs []]
     (if (< c n)
-      (if-let [v (read-fn reader)]
+      (if-let [v (read-fn reader context)]
         (recur
           (if (p? v) (inc c) c)
           (conj vs v))


### PR DESCRIPTION
Upstream improvement already merged into Kondo as https://github.com/clj-kondo/clj-kondo/pull/2785. This took me longer to port because upstream and Kondo fork have diverged quite a bit in these files.

This is also performance-related. Dynamic variable manipulation is quite expensive.

Benchmark:

```
(time+ (rewrite-clj.parser/parse-file-all "src/rewrite_clj/zip.cljc"))

Before: 
Time per call: 5.60 ms   Alloc per call: 6,960,545b
Time per call: 5.56 ms   Alloc per call: 6,960,544b
Time per call: 5.63 ms   Alloc per call: 6,960,544b

After:
Time per call: 4.63 ms   Alloc per call: 4,100,688b
Time per call: 4.65 ms   Alloc per call: 4,100,688b
Time per call: 4.65 ms   Alloc per call: 4,100,622b
```

Roughly another 17% speed and 40% allocation improvement.

---

I have:
- [x] read and have followed [Contributing Guidelines](https://github.com/clj-commons/rewrite-clj/blob/main/CONTRIBUTING.md).
- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
