### PR TITLE
perf: Use more efficient StringBuilder.append arity

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,8 @@ A release with known breaking changes is marked with:
 
 * perf: pass explicit context instead *delimiter* dynvar.
 {issue}442[#442] ({person}alexander-yakushev[@alexander-yakushev])
+* perf: Use more efficient StringBuilder.append arity
+{issue}443[#443] ({person}alexander-yakushev[@alexander-yakushev])
 
 === v1.2.53 - 2026-03-12 [[v1.2.53]]
 

--- a/src/rewrite_clj/parser/impl.cljc
+++ b/src/rewrite_clj/parser/impl.cljc
@@ -5,29 +5,23 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(defn flush-into
-  "INTERNAL. Flush buffer and add string to the given vector."
-  [lines ^StringBuffer buf]
-  (let [s (.toString buf)]
-    #?(:clj (.setLength buf 0) :cljs (.clear buf))
-    (conj lines s)))
+(defn- make-buffer []
+  #?(:clj (StringBuilder.) :cljs (StringBuffer.)))
 
 (defn read-string-data
   "INTERNAL."
   [#?(:cljs ^not-native reader :default reader)]
   (reader/ignore reader)
-  (let [buf (StringBuffer.)]
-    (loop [escape? false
-           lines []]
-      (if-let [c (reader/next reader)]
-        (cond (and (not escape?) (identical? c \"))
-              (flush-into lines buf)
+  (loop [escape? false, lines [], buf (make-buffer)]
+    (if-let [c (reader/next reader)]
+      (cond (and (not escape?) (identical? c \"))
+            (conj lines (str buf))
 
-              (identical? c \newline)
-              (recur escape? (flush-into lines buf))
+            (identical? c \newline)
+            (recur escape? (conj lines (str buf)) (make-buffer))
 
-              :else
-              (do
-                (.append buf c)
-                (recur (and (not escape?) (identical? c \\)) lines)))
-        (reader/throw-reader reader "Unexpected EOF while reading string.")))))
+            :else
+            (do #?(:clj (.append ^StringBuilder buf (char c))
+                   :cljs (.append ^StringBuffer buf (char c)))
+                (recur (and (not escape?) (identical? c \\)) lines buf)))
+      (reader/throw-reader reader "Unexpected EOF while reading string."))))

--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -75,12 +75,12 @@
    (read-while reader p? (not (p? nil))))
 
   ([#?(:cljs ^not-native reader :default reader) p? eof?]
-   (let [buf (StringBuffer.)]
+   (let [buf #?(:clj (StringBuilder.) :cljs (StringBuffer.))]
      (loop []
        (if-let [c (r/read-char reader)]
          (if (p? c)
            (do
-             (.append buf c)
+             (.append buf (char c))
              (recur))
            (do
              (r/unread reader c)


### PR DESCRIPTION
The currently used arity treats a character as Object which forces `Object.toString` for each char before appending. By casting to `char`, the arity is used that writes directly to StringBuilder backing array.

Also replace StringBuffers with StringBuilders as the latter doesn't pay the penalty of being unnecessarily synchronized.

Benchmark:

```
(time+ (rewrite-clj.parser/parse-file-all "src/rewrite_clj/zip.cljc"))

Before: 
Time per call: 4.56 ms   Alloc per call: 4,121,281b
Time per call: 4.59 ms   Alloc per call: 4,121,280b
Time per call: 4.51 ms   Alloc per call: 4,121,233b

After:
Time per call: 4.09 ms   Alloc per call: 2,044,072b
Time per call: 4.07 ms   Alloc per call: 2,043,969b
Time per call: 4.07 ms   Alloc per call: 2,043,952b
```

-10% execution time, -50% allocations.

---

- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
