### PR TITLE
perf: Reader optimizations

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,8 @@ A release with known breaking changes is marked with:
 {issue}442[#442] ({person}alexander-yakushev[@alexander-yakushev])
 * perf: Use more efficient StringBuilder.append arity
 {issue}443[#443] ({person}alexander-yakushev[@alexander-yakushev])
+* perf: Reader optimizations
+{issue}444[#444] ({person}alexander-yakushev[@alexander-yakushev])
 
 === v1.2.53 - 2026-03-12 [[v1.2.53]]
 

--- a/src/rewrite_clj/interop.cljc
+++ b/src/rewrite_clj/interop.cljc
@@ -32,7 +32,9 @@
 
 (defn clojure-whitespace?
   [#?(:clj ^java.lang.Character c :default c)]
-  #?(:clj (and c (or (= c \,) (Character/isWhitespace c)))
+  #?(:clj (cond (nil? c) false
+                (identical? c \,) true
+                :else (Character/isWhitespace c))
      :cljs (and c (< -1 (.indexOf #js [\return \newline \tab \space ","] c)))))
 
 (defn meta-available?

--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -34,10 +34,9 @@
 (defn boundary?
   "Check whether a given char is a token boundary."
   [#?(:clj ^java.lang.Character c :default c)]
-  (contains?
-    #{\" \: \; \' \@ \^ \` \~
-      \( \) \[ \] \{ \} \\ nil}
-    c))
+  ;; Note: indexOf here is more efficient that a hashset of characters.
+  #?(:clj (or (nil? c) (> (.indexOf "\":;'@^`~()[]{}\\" (int c)) -1))
+     :cljs (contains? #{\" \: \; \' \@ \^ \` \~\( \) \[ \] \{ \} \\ nil} c)))
 
 (defn comma?
   [#?(:clj ^java.lang.Character c :default c)]
@@ -52,19 +51,20 @@
 (defn linebreak?
   "Checks whether the character is a newline"
   [#?(:clj ^java.lang.Character c :default c)]
-  (contains? #{\newline \return} c))
+  (or (identical? c \newline) (identical? c \return)))
 
 (defn space?
   "Checks whether the character is a space"
   [#?(:clj ^java.lang.Character c :default c)]
   (and c
-       (whitespace? c)
-       (not (contains? #{\newline \return \,} c))))
+       (interop/clojure-whitespace? c)
+       (not (identical? c \newline))
+       (not (identical? c \,))))
 
 (defn whitespace-or-boundary?
   #?(:clj ^Boolean [^java.lang.Character c]
           :default [c])
-  (or (whitespace? c) (boundary? c)))
+  (or (interop/clojure-whitespace? c) (boundary? c)))
 
 ;; ## Helpers
 


### PR DESCRIPTION
A set of smaller optimizations.
- Combine namespace part and name part into a Symbol object early, don't use an intermediate tuple.
- Optimize character-checking predicates to use direct equality statements and `String/.indexOf` instead of hashsets.

Benchmark:

```
(time+ (rewrite-clj.parser/parse-file-all "src/rewrite_clj/zip.cljc"))

Time per call: 4.26 ms   Alloc per call: 2,082,343b
Time per call: 4.31 ms   Alloc per call: 2,082,273b
Time per call: 4.10 ms   Alloc per call: 2,082,272b

Time per call: 4.01 ms   Alloc per call: 1,990,249b
Time per call: 3.97 ms   Alloc per call: 1,990,248b
Time per call: 3.98 ms   Alloc per call: 1,990,129b
```

This gives us a modest -5% time and -5% allocations. Ain't much but honest work.

---

- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
