### PR TITLE
[perf] Add fastpaths to rewrite-clj.node.stringz/sexpr

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,9 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 === Unreleased
 
+* perf: Add fastpaths to rewrite-clj.node.stringz/sexpr
+{issue}458[#458] ({person}alexander-yakushev[@alexander-yakushev])
+
 === v1.2.54 - 2026-03-16 [[v1.2.54]]
 
 * perf: pass explicit context instead *delimiter* dynvar.

--- a/src/rewrite_clj/node/stringz.cljc
+++ b/src/rewrite_clj/node/stringz.cljc
@@ -13,6 +13,12 @@
 (defn- join-lines [lines]
   (string/join "\n" lines))
 
+(defn- maybe-unescape
+  [s]
+  (if (string/includes? s "\\")
+    (edn/read-string (wrap-string s))
+    s))
+
 (defrecord StringNode [lines]
   node/Node
   (tag [_node]
@@ -22,10 +28,9 @@
   (node-type [_node] :string)
   (printable-only? [_node] false)
   (sexpr* [_node _opts]
-    (join-lines
-      (map
-        (comp edn/read-string wrap-string)
-        lines)))
+    (if (= (count lines) 1)
+      (maybe-unescape (nth lines 0))
+      (join-lines (map maybe-unescape lines))))
   (length [_node]
     (+ 2 (reduce + (map count lines))))
   (string [_node]


### PR DESCRIPTION
_These changes are needed for https://github.com/clj-kondo/clj-kondo/pull/2853, but we need to test them for regressions here first. See that ticket for details._

Kondo calls `sexpr` quite a bit, which in turn invokes different rewrite-clj Node implementations of sexpr. StringNode in particular is expensive because it performs indiscriminate roundtrip through edn/read-string where in most strings it is not needed.

The proposed added fastpath removes ~3% allocations and comparatively reduces the execution time.

---

- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
