### PR TITLE
[parser] Optimize parse-token

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,8 @@ A release with known breaking changes is marked with:
 {issue}443[#443] ({person}alexander-yakushev[@alexander-yakushev])
 * perf: Reader optimizations
 {issue}444[#444] ({person}alexander-yakushev[@alexander-yakushev])
+* perf: Optimize parse-token
+{issue}459[#459] ({person}alexander-yakushev[@alexander-yakushev])
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.2.53\...v1.2.54[commit log]
 

--- a/src/rewrite_clj/parser/token.cljc
+++ b/src/rewrite_clj/parser/token.cljc
@@ -1,38 +1,44 @@
 (ns ^:no-doc rewrite-clj.parser.token
   (:require [rewrite-clj.interop :as interop]
             [rewrite-clj.node.token :as ntoken]
-            [rewrite-clj.reader :as r]))
+            [rewrite-clj.reader :as r])
+  #?@(:cljs [(:import [goog.string StringBuffer])]
+      :default []))
 
 #?(:clj (set! *warn-on-reflection* true))
 
+;; Next two functions are extract to avoid allocating fn objects in refsites.
+
+(defn- not-boundary? [c] (not (r/whitespace-or-boundary? c)))
+
+(defn- not-boundary-allow-extra? [c]
+  (or (#{\' \:} c)
+      (not (r/whitespace-or-boundary? c))))
+
 (defn- read-to-boundary
-  ([#?(:cljs ^not-native reader :default reader)]
-   (read-to-boundary reader #{}))
-  ([#?(:cljs ^not-native reader :default reader) allowed?]
-   (r/read-until
-    reader
-    #(and (not (allowed? %))
-          (r/whitespace-or-boundary? %)))))
+  [#?(:cljs ^not-native reader :default reader) buf f]
+  (r/read-into-buffer-while reader buf f true))
 
 (defn- read-to-char-boundary
-  [#?(:cljs ^not-native reader :default reader)]
+  [#?(:cljs ^not-native reader :default reader)
+   #?(:clj ^StringBuilder buf :default ^StringBuffer buf)]
   (let [c (r/next reader)]
-    (str c
-         (if (not= c \\)
-           (read-to-boundary reader)
-           ""))))
+    (.append buf (char c))
+    (when-not (= c \\)
+      (read-to-boundary reader buf not-boundary?))))
 
 (defn- symbol-node
   "Symbols allow for certain boundary characters that have
    to be handled explicitly."
-  [#?(:cljs ^not-native reader :default reader) value value-string]
-  (let [suffix (read-to-boundary reader #{\' \:})]
-    (if (empty? suffix)
+  [#?(:cljs ^not-native reader :default reader) value value-string
+   #?(:clj ^StringBuilder buf :default ^StringBuffer buf)]
+  (let [length-before (#?(:clj .length :cljs .getLength) buf)
+        _ (read-to-boundary reader buf not-boundary-allow-extra?)
+        length-after (#?(:clj .length :cljs .getLength) buf)]
+    (if (= length-before length-after)
       (ntoken/token-node value value-string)
-      (let [s (str value-string suffix)]
-        (ntoken/token-node
-          (r/read-symbol s)
-          s)))))
+      (let [s (str buf)]
+        (ntoken/token-node (r/string->edn s) s)))))
 
 (defn- number-literal?
   "Checks whether the reader is at the start of a number literal
@@ -46,18 +52,20 @@
 (defn parse-token
   "Parse a single token. For example: symbol, number or character."
   [#?(:cljs ^not-native reader :default reader)]
-  (let [first-char (r/next reader)
-        s (->> (if (= first-char \\)
-                 (read-to-char-boundary reader)
-                 (read-to-boundary reader))
-               (str first-char))
+  (let [buf #?(:clj (StringBuilder.) :cljs (StringBuffer.))
+        first-char (r/next reader)
+        _ (.append buf (char first-char))
+        _ (if (= first-char \\)
+            (read-to-char-boundary reader buf)
+            (read-to-boundary reader buf not-boundary?))
+        s (str buf)
         v (if (or (= first-char \\) ;; character like \n or \newline
                   (= first-char \#) ;; something like ##Inf, ##Nan
                   (number-literal? s))
             (r/string->edn s)
             (r/read-symbol s))]
     (if (symbol? v)
-      (symbol-node reader v s)
+      (symbol-node reader v s buf)
       (ntoken/token-node v s))))
 
 (comment

--- a/src/rewrite_clj/parser/token.cljc
+++ b/src/rewrite_clj/parser/token.cljc
@@ -22,10 +22,12 @@
 (defn- read-to-char-boundary
   [#?(:cljs ^not-native reader :default reader)
    #?(:clj ^StringBuilder buf :default ^StringBuffer buf)]
-  (let [c (r/next reader)]
-    (.append buf (char c))
-    (when-not (= c \\)
-      (read-to-boundary reader buf not-boundary?))))
+  (if-let [c (r/next reader)]
+    (do (.append buf (char c))
+        (when-not (= c \\)
+          (read-to-boundary reader buf not-boundary?)))
+    ;; At least one char must be present after \
+    (r/throw-reader reader "Unexpected EOF")))
 
 (defn- symbol-node
   "Symbols allow for certain boundary characters that have
@@ -38,7 +40,7 @@
     (if (= length-before length-after)
       (ntoken/token-node value value-string)
       (let [s (str buf)]
-        (ntoken/token-node (r/string->edn s) s)))))
+        (ntoken/token-node (r/read-symbol s) s)))))
 
 (defn- number-literal?
   "Checks whether the reader is at the start of a number literal

--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -68,6 +68,23 @@
 
 ;; ## Helpers
 
+(defn read-into-buffer-while
+  "Read while the chars fulfill the given condition and append them into the
+  provided buffer. Ignores the unmatching char."
+  [reader #?(:clj ^StringBuilder buf :default ^StringBuffer buf) p? eof?]
+  (let [eof? (if (nil? eof?)
+               (not (p? nil))
+               eof?)]
+    (loop []
+      (if-let [c (r/read-char reader)]
+        (if (p? c)
+          (do
+            (.append buf (char c))
+            (recur))
+          (r/unread reader c))
+        (when-not eof?
+          (throw-reader reader "unexpected EOF"))))))
+
 (defn read-while
   "Read while the chars fulfill the given condition. Ignores
     the unmatching char."
@@ -76,18 +93,8 @@
 
   ([#?(:cljs ^not-native reader :default reader) p? eof?]
    (let [buf #?(:clj (StringBuilder.) :cljs (StringBuffer.))]
-     (loop []
-       (if-let [c (r/read-char reader)]
-         (if (p? c)
-           (do
-             (.append buf (char c))
-             (recur))
-           (do
-             (r/unread reader c)
-             (.toString buf)))
-         (if eof?
-           (.toString buf)
-           (throw-reader reader "unexpected EOF")))))))
+     (read-into-buffer-while reader buf p? eof?)
+     (.toString buf))))
 
 (defn read-until
   "Read until a char fulfills the given condition. Ignores the

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -584,6 +584,7 @@
            ["[def"                  #".*Unexpected EOF.*"]
            ["#{def"                 #".*Unexpected EOF.*"]
            ["{:a 0"                 #".*Unexpected EOF.*"]
+           ["\\"                    #".*Unexpected EOF.*"]
            ["\"abc"                 #".*EOF.*"]
            ["#\"abc"                #".*Unexpected EOF.*"]
            ["(def x 0]"             #".*Unmatched delimiter.*"]


### PR DESCRIPTION
The main idea behind this change is to avoid calling `(str first-char <rest-of-chars-from-the-reader>)` which is quite expensive for several reasons. Instead, use an once-allocated StringBuilder surgically to construct the resulting token with fewer redundant allocations.

Benchmark:
```clj
(set! *assert* false)

(def all-metabase-files
  (vec (filter #(re-find #"\.clj(c|s)?$" (str %))
               (concat (file-seq (clojure.java.io/file "../metabase/src"))
                       (file-seq (clojure.java.io/file "../metabase/test"))))))

(time+ (run! parse-file-all all-metabase-files))
```

Results – -10% time, -16% allocations:
```
Before:
Time per call: 3.21 s   Alloc per call: 2,226,049,568b
Time per call: 3.22 s   Alloc per call: 2,225,898,944b
Time per call: 3.25 s   Alloc per call: 2,225,805,720b

After:
Time per call: 2.95 s   Alloc per call: 1,876,605,800b 
Time per call: 2.96 s   Alloc per call: 1,876,601,896b
Time per call: 2.95 s   Alloc per call: 1,876,607,792b
```

DIffgraph: https://flamebin.dev/zhEKbj

---

- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
