### PR TITLE
[parser] Reuse common whitespace and newline nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,10 @@ A release with known breaking changes is marked with:
 
 * perf: Add fastpaths to rewrite-clj.node.stringz/sexpr
 {issue}458[#458] ({person}alexander-yakushev[@alexander-yakushev])
+* perf: Optimize parse-token
+{issue}459[#459] ({person}alexander-yakushev[@alexander-yakushev])
+* perf: Reuse common whitespace and newline nodes
+{issue}460[#460] ({person}alexander-yakushev[@alexander-yakushev])
 
 === v1.2.54 - 2026-03-16 [[v1.2.54]]
 
@@ -35,8 +39,6 @@ A release with known breaking changes is marked with:
 {issue}443[#443] ({person}alexander-yakushev[@alexander-yakushev])
 * perf: Reader optimizations
 {issue}444[#444] ({person}alexander-yakushev[@alexander-yakushev])
-* perf: Optimize parse-token
-{issue}459[#459] ({person}alexander-yakushev[@alexander-yakushev])
 
 https://github.com/clj-commons/rewrite-clj/compare/v1.2.53\...v1.2.54[commit log]
 

--- a/src/rewrite_clj/parser/whitespace.cljc
+++ b/src/rewrite_clj/parser/whitespace.cljc
@@ -4,19 +4,44 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+(def ^:private single-space-node (nwhitespace/whitespace-node " "))
+
+(defn- parse-spaces
+  [#?(:cljs ^not-native reader :default reader)]
+  ;; Heuristic: most whitespace nodes are only one character long. Reuse the
+  ;; same whitespace node object for all of them.
+  (let [first-char (reader/next reader)]
+    (if (reader/space? (reader/peek reader))
+      (do (reader/unread reader first-char)
+          (nwhitespace/whitespace-node
+           (reader/read-while reader reader/space?)))
+      (if (= first-char \space)
+        single-space-node
+        (nwhitespace/whitespace-node (str first-char))))))
+
+(def ^:private single-newline-node (nwhitespace/newline-node "\n"))
+
+(defn- parse-linebreaks
+  [#?(:cljs ^not-native reader :default reader)]
+  ;; Same heuristic as for spaces.
+  (let [first-char (reader/next reader)]
+    (if (reader/linebreak? (reader/peek reader))
+      (do (reader/unread reader first-char)
+          (nwhitespace/newline-node (reader/read-while reader reader/linebreak?)))
+      (if (= first-char \newline)
+        single-newline-node
+        (nwhitespace/newline-node (str first-char))))))
+
 (defn parse-whitespace
   "Parse as much whitespace as possible. The created node can either contain
    only linebreaks or only space/tabs."
   [#?(:cljs ^not-native reader :default reader)]
   (let [c (reader/peek reader)]
     (cond (reader/linebreak? c)
-          (nwhitespace/newline-node
-            (reader/read-while reader reader/linebreak?))
+          (parse-linebreaks reader)
 
           (reader/comma? c)
           (nwhitespace/comma-node
             (reader/read-while reader reader/comma?))
 
-          :else
-          (nwhitespace/whitespace-node
-            (reader/read-while reader reader/space?)))))
+          :else (parse-spaces reader))))


### PR DESCRIPTION
Easy stuff here: the most common whitespace nodes are just single spaces, and most common newline nodes are just single lines. This gives us two spots for potential saving:
- Don't allocate a StringBuffer if we only need to read one char and ensure the next one is a non-whitespace.
- Reuse single-space and single-newline immutable singletons to again avoid allocations, but also reduce memory footprint.

Benchmark:

```clj
(set! *assert* false)

(def all-metabase-files
  (vec (filter #(re-find #"\.clj(c|s)?$" (str %))
               (concat (file-seq (clojure.java.io/file "../metabase/src"))
                       (file-seq (clojure.java.io/file "../metabase/test"))
                       (file-seq (clojure.java.io/file "../metabase/enterprise"))
                       (file-seq (clojure.java.io/file "../metabase/modules"))))))

(time+ (run! parse-file-all all-metabase-files))
```

Results – -6% time, -14% allocations:

```
Before:
Time per call: 4.56 s   Alloc per call: 3,073,353,432b
Time per call: 4.57 s   Alloc per call: 3,073,339,504b
Time per call: 4.57 s   Alloc per call: 3,073,333,456b

After:
Time per call: 4.34 s   Alloc per call: 2,658,082,712b
Time per call: 4.30 s   Alloc per call: 2,658,053,848b
Time per call: 4.32 s   Alloc per call: 2,658,034,088b
```

---

- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
