### PR TITLE
[reader] Simplify NewlineNormalizingReader

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,8 @@ A release with known breaking changes is marked with:
 {issue}459[#459] ({person}alexander-yakushev[@alexander-yakushev])
 * perf: Reuse common whitespace and newline nodes
 {issue}460[#460] ({person}alexander-yakushev[@alexander-yakushev])
+* perf: Simplify NewlineNormalizingReader
+{issue}461[#461] ({person}alexander-yakushev[@alexander-yakushev])
 
 === v1.2.54 - 2026-03-16 [[v1.2.54]]
 

--- a/src/rewrite_clj/reader.cljc
+++ b/src/rewrite_clj/reader.cljc
@@ -277,38 +277,45 @@
 ;; Once/if this isssue is fixed in in tools reader we can turf our work-around.
 
 #?(:clj
-   (deftype NewlineNormalizingReader
-       [rdr
-        ^:unsynchronized-mutable read-ahead-char
-        ^:unsynchronized-mutable user-peeked-char]
+   (deftype NewlineNormalizingReader [rdr]
      r/Reader
      (read-char [_reader]
-       (if-let [ch user-peeked-char]
-         (do (set! user-peeked-char nil) ch)
-         (let [ch (or read-ahead-char (r/read-char rdr))]
-           (when read-ahead-char (set! read-ahead-char nil))
-           (if (not (identical? \return ch))
-             ch
-             (let [read-ahead-ch (r/read-char rdr)]
-               (when (not (or (identical? \newline read-ahead-ch)
-                              (identical? \formfeed read-ahead-ch)))
-                 (set! read-ahead-char read-ahead-ch))
-               \newline)))))
+       (let [ch (r/read-char rdr)]
+         (if-not (identical? \return ch)
+           ;; Happy path
+           ch
+           ;; Complicated path
+           (let [ch2 (r/read-char rdr)]
+             (when-not (or (identical? \newline ch2)
+                           (identical? \formfeed ch2))
+               (r/unread rdr ch2))
+             \newline))))
 
-     (peek-char [reader]
-       (or user-peeked-char
-           (let [ch (.read-char reader)]
-             (set! user-peeked-char ch)
-             ch)))))
+     (peek-char [_reader]
+       (let [ch (r/peek-char rdr)]
+         (if (identical? \return ch)
+           \newline
+           ch)))
+
+     r/IPushbackReader
+     (unread [_reader ch] (r/unread rdr ch))))
 
 #?(:clj
    (defn newline-normalizing-reader
      "Normalizes the following line endings to LF (line feed - 0x0A):
       - LF (remains LF)
       - CRLF (carriage return 0x0D line feed 0x0A)
-      - CRFF (carriage return 0x0D form feed 0x0C)"
-     ^Closeable [rdr]
-     (NewlineNormalizingReader. (r/to-rdr rdr) nil nil)))
+      - CRFF (carriage return 0x0D form feed 0x0C)
+      IMPORTANT: `pbr` must be an IPushbackReader with a buffer of at least 2."
+     ^Closeable [pbr]
+     {:pre [(satisfies? r/IPushbackReader pbr)]}
+     (->NewlineNormalizingReader pbr)))
+
+(defn- indexing-reader
+  "Creates a new IndexingPushbackReader from a reader that is assumed to already
+  be a IPushbackReader, hence no double PushbackReader-wrapping is performed.`"
+  [pbr]
+  (r/->IndexingPushbackReader pbr 1 1 true nil 0 nil false))
 
 #?(:clj
    (defn file-reader
@@ -319,12 +326,12 @@
          (io/reader)
          (PushbackReader. 2)
          newline-normalizing-reader
-         (r/indexing-push-back-reader 2))))
+         indexing-reader)))
 
 (defn string-reader
   "Create reader for strings."
   [s]
   (-> s
-      r/string-push-back-reader
+      (r/string-push-back-reader 2)
       #?@(:clj [newline-normalizing-reader])
-      r/indexing-push-back-reader))
+      indexing-reader))


### PR DESCRIPTION
Two benefits:
- More straightforward implementation – there is no need to manually "buffer" the read characters in the deftype fields, we can rely on the underlying PBR to unread the hanging chars.
- Some performance is reclaimed by not wrapping the reader stack (which is already quite large and inefficient, to be honest) in another PushbackReader. To do that, we have to pinky-promise the IndexingPushbackReader that we pass a IPBr instance to it.

Benchmark:

```clj
(set! *assert* false)

(def all-metabase-files
  (vec (filter #(re-find #"\.clj(c|s)?$" (str %))
               (concat (file-seq (clojure.java.io/file "../metabase/src"))
                       (file-seq (clojure.java.io/file "../metabase/test"))
                       (file-seq (clojure.java.io/file "../metabase/enterprise"))
                       (file-seq (clojure.java.io/file "../metabase/modules"))))))

(time+ (run! parse-file-all all-metabase-files))
```

Results – -5% time, it's not very consistent, but overall the implementation is simpler, so it shouldn't at least we worse.

```
Before:
Time per call: 3.85 s   Alloc per call: 2,291,580,744b
Time per call: 3.94 s   Alloc per call: 2,291,390,944b
Time per call: 3.86 s   Alloc per call: 2,291,306,768b

After:
Time per call: 3.64 s   Alloc per call: 2,287,769,600b
Time per call: 3.64 s   Alloc per call: 2,287,731,024b
Time per call: 3.66 s   Alloc per call: 2,287,709,056b
```

---

- [ ] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
