### PR TITLE
[parser] Fix crash when 1-char buffer PBR is provided

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,6 +24,9 @@ A release with known breaking changes is marked with:
 //   (adjust these in publish.clj as you see fit)
 === Unreleased
 
+* fix: Don't crash when 1-char buffer PBR is provided.
+{issue}466[#466] ({person}alexander-yakushev[@alexander-yakushev])
+
 === v1.2.55 - 2026-06-19 [[v1.2.55]]
 
 * perf: Add fastpaths to rewrite-clj.node.stringz/sexpr

--- a/src/rewrite_clj/parser/whitespace.cljc
+++ b/src/rewrite_clj/parser/whitespace.cljc
@@ -1,6 +1,7 @@
 (ns ^:no-doc rewrite-clj.parser.whitespace
   (:require [rewrite-clj.node.whitespace :as nwhitespace]
-            [rewrite-clj.reader :as reader]))
+            [rewrite-clj.reader :as reader])
+  #?@(:cljs [(:import [goog.string StringBuffer])]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -12,9 +13,10 @@
   ;; same whitespace node object for all of them.
   (let [first-char (reader/next reader)]
     (if (reader/space? (reader/peek reader))
-      (do (reader/unread reader first-char)
-          (nwhitespace/whitespace-node
-           (reader/read-while reader reader/space?)))
+      (let [buf #?(:clj (StringBuilder.) :cljs (StringBuffer.))]
+        (.append buf first-char)
+        (reader/read-into-buffer-while reader buf reader/space? true)
+        (nwhitespace/whitespace-node (str buf)))
       (if (= first-char \space)
         single-space-node
         (nwhitespace/whitespace-node (str first-char))))))
@@ -26,8 +28,10 @@
   ;; Same heuristic as for spaces.
   (let [first-char (reader/next reader)]
     (if (reader/linebreak? (reader/peek reader))
-      (do (reader/unread reader first-char)
-          (nwhitespace/newline-node (reader/read-while reader reader/linebreak?)))
+      (let [buf #?(:clj (StringBuilder.) :cljs (StringBuffer.))]
+        (.append buf first-char)
+        (reader/read-into-buffer-while reader buf reader/linebreak? true)
+        (nwhitespace/newline-node (str buf)))
       (if (= first-char \newline)
         single-newline-node
         (nwhitespace/newline-node (str first-char))))))
@@ -42,6 +46,6 @@
 
           (reader/comma? c)
           (nwhitespace/comma-node
-            (reader/read-while reader reader/comma?))
+           (reader/read-while reader reader/comma?))
 
           :else (parse-spaces reader))))

--- a/test/rewrite_clj/parser_test.cljc
+++ b/test/rewrite_clj/parser_test.cljc
@@ -6,8 +6,8 @@
             [clojure.tools.reader :as rdr]
             [rewrite-clj.node :as node]
             [rewrite-clj.parser :as p])
-  #?(:clj (:import [clojure.lang ExceptionInfo]
-                   [java.io File])))
+  #?(:clj (:import [clojure.lang ExceptionInfo LineNumberingPushbackReader]
+                   [java.io File StringReader])))
 
 (deftest t-parsing-the-first-few-whitespaces
   (doseq [[ws parsed]
@@ -773,3 +773,8 @@
         m-str (pr-str m)
         m-sexpr (-> m-str p/parse-string node/sexpr)]
     (is (= (keys m) (keys m-sexpr)))))
+
+#?(:clj
+   (deftest one-char-pushback-reader
+     (testing "parsing doesn't crash if the provided PBR only has a buffer of 1 char"
+       (is (p/parse-all (LineNumberingPushbackReader. (StringReader. "1\n\n\n2")))))))


### PR DESCRIPTION
By using a peek + instantly unreading, the recent changes to `.whitespace` namespace (#460) thus put a requirement on the reader to have at least 2-character pushback buffer. For the buffers we construct ourselves, this is already true. However, the user can provide a custom reader to `parser/read-all` with a buffer of 1.

This PR fixes the issue. Instead of unreading, we now put the first character into our own StringBuffer and then fill up the rest of the consecutive whitespace/newline characters.

---

- [x] added/updated tests to cover my change.
- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
