### PR TITLE
test: bump clojure 1.13.0 to alpha5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,7 +22,7 @@
            :clojure-1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
            :clojure-1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.5"}}}
            ;; Candidate release is :clojure-pre-* (ex. clojure-pre-1.13.0) (if any)
-           :clojure-pre-1.13.0-alpha {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha4"}}}
+           :clojure-pre-1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha5"}}}
 
            ;;
            ;; ClojureScript version we test with (and support)

--- a/script/helper/clojure_versions.clj
+++ b/script/helper/clojure_versions.clj
@@ -1,19 +1,23 @@
 (ns helper.clojure-versions
   (:require [clojure.edn :as edn]
+            [version-clj.core :as version]
             [wevre.natural-compare :as natural-compare]))
 
 (defn all
   "Returns vector of maps with :version :alias :pre-release?"
-  [] 
+  []
   (->> (slurp "deps.edn")
        edn/read-string
        :aliases
-       keys
-       (keep (fn [k]
+       (keep (fn [[k v]]
                (when-let [[_ prefix version] (re-find #"(clojure-pre-|clojure-)(.*)" (name k))]
-                 {:version version
-                  :alias k
-                  :pre-release? (= "clojure-pre-" prefix)})))
+                 (if-let [mvn-version (get-in v [:override-deps 'org.clojure/clojure :mvn/version])]
+                   {:version version
+                    :mvn-version mvn-version
+                    :alias k
+                    :pre-release? (= "clojure-pre-" prefix)
+                    :min-jdk-major (if (version/newer-or-equal? mvn-version "1.13-alpha5") 17 8)}
+                   (throw (ex-info (str "failed to find mvn/version for alias " k) {}))))))
        (sort-by :version natural-compare/natural-compare)
        (into [])))
 

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -3,6 +3,7 @@
 (ns test-clj
   (:require [clojure.string :as str]
             [helper.clojure-versions :as clojure-versions]
+            [helper.jdk :as jdk]
             [helper.main :as main]
             [helper.shell :as shell]
             [lread.status-line :as status]))
@@ -31,21 +32,28 @@
 
 Options:
   -v, --clojure-version VERSION  Test with Clojure [%s] [default: %s]
+                                 When specifying all, will skip testing version if your JDK < min required.
   --help                         Show this help"
                         (str/join ", " cli-clojure-versions)
                         (first cli-clojure-versions)))
 
 (defn -main [& args]
   (when-let [opts (main/doc-arg-opt args-usage args)]
-    (let [clojure-version (get opts "--clojure-version")]
+    (let [env-jdk-version (jdk/version)
+          clojure-version (get opts "--clojure-version")]
       (if (not (some #{clojure-version} cli-clojure-versions))
         (status/die 1 args-usage)
         (let [clojure-versions (if (= "all" clojure-version)
                                  (clojure-versions/all)
                                  [(clojure-versions/lookup clojure-version)])]
           (doseq [v clojure-versions]
-            (run-unit-tests v)
-            (run-isolated-tests v))))))
+            (if (and (= "all" clojure-version)
+                     (< (:major env-jdk-version) (:min-jdk-major v)))
+              (status/line :warn "Skipping testing clojure version %s\nIt requires min JDK %s, found JDK %s"
+                           (:mvn-version v) (:min-jdk-major v) (:version env-jdk-version))
+              (do
+                (run-unit-tests v)
+                (run-isolated-tests v))))))))
   nil)
 
 (main/when-invoked-as-script


### PR DESCRIPTION
This release of Clojure bumps min JDK from 8 to 17. For the near term, we'll continue to test on JDK 8 and 17 for older versions for Clojure.

`bb test-clj -v all` will skip testing 1.13.0-alpha5 and above with a warning if JDK < 17.

When testing a specific version of Clojure, no skipping is done, the test will fail naturally if the min JDK requirement is not met.

We appreciate your contribution. Please complete the following checklist (and leave it in as part of your PR):

I have:
- [x] read and have followed [Contributing Guidelines](https://github.com/clj-commons/rewrite-clj/blob/main/CONTRIBUTING.md).
- [ ] created a clear [issue](https://github.com/clj-commons/rewrite-clj/issues) and have gotten agreement to proceed from the project maintainers (unnecessary for typo fixes).
- [x] added/updated tests to cover my change.
- [ ] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
