### PR TITLE
Reduce stringbuilder allocation pressure

### DIFF
--- a/src/rewrite_clj/node/protocols.cljc
+++ b/src/rewrite_clj/node/protocols.cljc
@@ -70,7 +70,7 @@
 (defn concat-strings
   "Return string version of `nodes`."
   [nodes]
-  (reduce str (map string nodes)))
+  (string/join (map string nodes)))
 
 ;; ## Inner Node
 


### PR DESCRIPTION
Fixes the allocation issues described here: https://github.com/clj-commons/rewrite-clj/issues/478

I have:

- [x] read and have followed [Contributing Guidelines](https://github.com/clj-commons/rewrite-clj/blob/main/CONTRIBUTING.md).
- [x] created a clear [issue](https://github.com/clj-commons/rewrite-clj/issues) and have gotten agreement to proceed from the project maintainers (unnecessary for typo fixes).
  - https://github.com/clj-commons/rewrite-clj/issues/478 
- [x] added/updated tests to cover my change.
  - This should be an extact drop-in replacement. Existing coverage should handle this case 
- [x] described my change in the [Changelog](https://github.com/clj-commons/rewrite-clj/blob/main/CHANGELOG.adoc) (if user-facing).
  - Not user facing 
